### PR TITLE
Finished the `net.minecraft.render.entity` package

### DIFF
--- a/mappings/net/minecraft/client/gl/GlUniform.mapping
+++ b/mappings/net/minecraft/client/gl/GlUniform.mapping
@@ -13,11 +13,58 @@ CLASS net/minecraft/class_1217 net/minecraft/client/gl/GlUniform
 		ARG 2 datatype
 		ARG 3 count
 		ARG 4 program
+	METHOD method_11198 uoploadMatrix ()V
 	METHOD method_4176 getName ()Ljava/lang/String;
+	METHOD method_4177 setGlUniform (F)V
+		ARG 1 floatData0
+	METHOD method_4178 setGlUniform (FF)V
+		ARG 1 floatData0
+		ARG 2 floatData1
+	METHOD method_4179 setGlUniform (FFF)V
+		ARG 1 floatData0
+		ARG 2 floatData1
+		ARG 3 floatData2
+	METHOD method_4180 setGlUniform (FFFF)V
+		ARG 1 floatData0
+		ARG 2 floatData1
+		ARG 3 floatData2
+		ARG 4 floatData3
+	METHOD method_4181 setGlUniform (FFFFFFFFFFFFFFFF)V
+		ARG 1 floatData0
+		ARG 2 floatData1
+		ARG 3 floatData2
+		ARG 4 floatData3
+		ARG 5 floatData4
+		ARG 6 floatData5
+		ARG 7 floatData6
+		ARG 8 floatData7
+		ARG 9 floatData8
+		ARG 10 floatData9
+		ARG 11 floatData10
+		ARG 12 floatData11
+		ARG 13 floatData12
+		ARG 14 floatData13
+		ARG 15 floatData14
+		ARG 16 floatData15
+	METHOD method_4182 setGlUniform (IIII)V
+		ARG 1 intData0
+		ARG 2 intData1
+		ARG 3 intData2
+		ARG 4 intData3
 	METHOD method_4183 getTypeIndex (Ljava/lang/String;)I
 		ARG 0 typeName
+	METHOD method_4185 set ([F)V
+		ARG 1 floatData
 	METHOD method_4186 upload ()V
+	METHOD method_4187 setGlUniformSafely (FFFF)V
+		ARG 1 floatData0
+		ARG 2 floatData1
+		ARG 3 floatData2
+		ARG 4 floatData3
 	METHOD method_4188 setLoc (I)V
+		ARG 1 loc
 	METHOD method_4189 markStateDirty ()V
 	METHOD method_4190 uploadInts ()V
 	METHOD method_4191 uploadFloats ()V
+	METHOD method_9698 setMatrix (Ljavax/vecmath/Matrix4f;)V
+		ARG 1 matrix

--- a/mappings/net/minecraft/client/gl/GlUniform.mapping
+++ b/mappings/net/minecraft/client/gl/GlUniform.mapping
@@ -13,7 +13,7 @@ CLASS net/minecraft/class_1217 net/minecraft/client/gl/GlUniform
 		ARG 2 datatype
 		ARG 3 count
 		ARG 4 program
-	METHOD method_11198 uoploadMatrix ()V
+	METHOD method_11198 uploadMatrix ()V
 	METHOD method_4176 getName ()Ljava/lang/String;
 	METHOD method_4177 setGlUniform (F)V
 		ARG 1 floatData0

--- a/mappings/net/minecraft/client/gl/JsonGlProgram.mapping
+++ b/mappings/net/minecraft/client/gl/JsonGlProgram.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
+	FIELD field_10702 culled Z
 	FIELD field_5006 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_5007 UNIFORM Lnet/minecraft/class_1210;
 	FIELD field_5008 activeProgram Lnet/minecraft/class_1211;
@@ -13,6 +14,7 @@ CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
 	FIELD field_5018 name Ljava/lang/String;
 	FIELD field_5019 useCullFace Z
 	FIELD field_5020 uniformStateDirty Z
+	FIELD field_5021 blendState Lnet/minecraft/class_1209;
 	FIELD field_5022 attribLocs Ljava/util/List;
 	FIELD field_5023 attribNames Ljava/util/List;
 	FIELD field_5024 vertex Lnet/minecraft/class_1214;
@@ -20,14 +22,21 @@ CLASS net/minecraft/class_1211 net/minecraft/client/gl/JsonGlProgram
 	METHOD <init> (Lnet/minecraft/class_1258;Ljava/lang/String;)V
 		ARG 1 manager
 		ARG 2 name
+	METHOD method_4130 destroy ()V
 	METHOD method_4131 addSampler (Lcom/google/gson/JsonElement;)V
+		ARG 1 jsonElement
 	METHOD method_4132 getUniformByName (Ljava/lang/String;)Lnet/minecraft/class_1217;
 		ARG 1 name
 	METHOD method_4133 bindSampler (Ljava/lang/String;Ljava/lang/Object;)V
 		ARG 1 samplerName
+		ARG 2 o
 	METHOD method_4134 disable ()V
 	METHOD method_4135 addUniform (Lcom/google/gson/JsonElement;)V
+		ARG 1 jsonElement
+	METHOD method_4136 getUniform (Ljava/lang/String;)Lnet/minecraft/class_1217;
+		ARG 1 name
 	METHOD method_4137 enable ()V
+	METHOD method_4138 markDirty ()V
 	METHOD method_4139 getVsh ()Lnet/minecraft/class_1214;
 	METHOD method_4140 getFsh ()Lnet/minecraft/class_1214;
 	METHOD method_4141 getProgramRef ()I

--- a/mappings/net/minecraft/client/gui/DrawableHelper.mapping
+++ b/mappings/net/minecraft/client/gui/DrawableHelper.mapping
@@ -13,6 +13,8 @@ CLASS net/minecraft/class_681 net/minecraft/client/gui/DrawableHelper
 		ARG 3 v
 		ARG 4 width
 		ARG 5 height
+		ARG 6 uOffset
+		ARG 7 vOffset
 	METHOD method_2446 drawHorizontalLine (IIII)V
 		ARG 1 x1
 		ARG 2 x2

--- a/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
+++ b/mappings/net/minecraft/client/gui/hud/ChatHud.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_686 net/minecraft/client/gui/hud/ChatHud
+	FIELD field_10038 sentChats Ljava/util/List;
+	FIELD field_10039 chatLines Ljava/util/List;
+	FIELD field_10040 drawnLines Ljava/util/List;
 	FIELD field_2893 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_2894 client Lnet/minecraft/class_669;
 	FIELD field_2898 scrolledLines I
@@ -17,6 +20,7 @@ CLASS net/minecraft/class_686 net/minecraft/client/gui/hud/ChatHud
 		ARG 1 message
 	METHOD method_2485 addMessage (Lnet/minecraft/class_1444;I)V
 		ARG 1 message
+		ARG 2 id
 	METHOD method_2487 addToMessageHistory (Ljava/lang/String;)V
 		ARG 1 message
 	METHOD method_2488 reset ()V
@@ -33,3 +37,10 @@ CLASS net/minecraft/class_686 net/minecraft/client/gui/hud/ChatHud
 	METHOD method_2496 getHeight ()I
 	METHOD method_2497 getChatScale ()F
 	METHOD method_2498 getVisibleLineCount ()I
+	METHOD method_9205 addMessage (Lnet/minecraft/class_1444;IIZ)V
+		ARG 1 message
+		ARG 2 id
+		ARG 3 ticks
+		ARG 4 deleted
+	METHOD method_9206 formatText (Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 text

--- a/mappings/net/minecraft/client/gui/screen/AbstractStatsListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/AbstractStatsListWidget.mapping
@@ -1,4 +1,12 @@
 CLASS net/minecraft/class_775 net/minecraft/client/gui/screen/AbstractStatsListWidget
 	FIELD field_3349 statsScreen Lnet/minecraft/class_770;
+	FIELD field_3350 clickedIconId I
+	FIELD field_3351 entries Ljava/util/List;
 	METHOD <init> (Lnet/minecraft/class_770;)V
 		ARG 1 statsScreen
+	METHOD method_2890 renderStat (Lnet/minecraft/class_1679;II)V
+		ARG 1 stat
+		ARG 2 x
+		ARG 3 z
+	METHOD method_2894 click (I)V
+		ARG 1 buttonDownTime

--- a/mappings/net/minecraft/client/gui/screen/AchievementsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/AchievementsScreen.mapping
@@ -1,5 +1,29 @@
 CLASS net/minecraft/class_769 net/minecraft/client/gui/screen/AchievementsScreen
+	FIELD field_3311 MAX_COLUMN I
+	FIELD field_3312 MAX_ROW I
 	FIELD field_3313 ACHIEVEMENT_BACKGROUND Lnet/minecraft/class_1605;
+	FIELD field_3314 scrolling I
 	FIELD field_3315 handler Lnet/minecraft/class_1688;
+	FIELD field_3316 notReady Z
+	FIELD field_3317 parent Lnet/minecraft/class_2292;
+	FIELD field_3318 iconWidth I
+	FIELD field_3319 iconHeight I
+	FIELD field_3320 prevMouseX I
+	FIELD field_3321 prevMouseY I
+	FIELD field_3322 scale F
+	FIELD field_3323 mouseX D
+	FIELD field_3324 mouseY D
+	FIELD field_3325 newMouseX D
+	FIELD field_3326 newMouseY D
+	FIELD field_3327 xStart D
+	FIELD field_3328 yStart D
+	FIELD field_3329 MIN_COLUMN I
+	FIELD field_3330 MIN_ROW I
 	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_1688;)V
+		ARG 1 parent
 		ARG 2 handler
+	METHOD method_10940 setTitle ()V
+	METHOD method_2858 renderIcons (IIF)V
+		ARG 1 mouseX
+		ARG 2 mouseY
+		ARG 3 tickdelta

--- a/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ChatScreen.mapping
@@ -3,4 +3,23 @@ CLASS net/minecraft/class_2287 net/minecraft/client/gui/screen/ChatScreen
 	FIELD field_10067 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_10068 lastChatMessage Ljava/lang/String;
 	FIELD field_10069 messageHistorySize I
+	FIELD field_10070 reset Z
+	FIELD field_10071 completed Z
+	FIELD field_10072 currentMessageId I
+	FIELD field_10073 messageHistory Ljava/util/List;
+	FIELD field_10074 uri Ljava/net/URI;
 	FIELD field_10075 initialChatText Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;)V
+		ARG 1 initialChatText
+	METHOD method_9213 reset ()V
+	METHOD method_9214 sendMessage (Ljava/lang/String;)V
+		ARG 1 message
+	METHOD method_9215 goThroughHistory (Ljava/lang/String;Ljava/lang/String;)V
+		ARG 1 text
+		ARG 2 cursor
+	METHOD method_9216 openLink (Ljava/net/URI;)V
+		ARG 1 uri
+	METHOD method_9217 setMessageHistory ([Ljava/lang/String;)V
+		ARG 1 messages
+	METHOD method_9218 goThroughHistory (I)V
+		ARG 1 numberOfNewMessages

--- a/mappings/net/minecraft/client/gui/screen/ConfirmChatLinkScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConfirmChatLinkScreen.mapping
@@ -3,4 +3,10 @@ CLASS net/minecraft/class_724 net/minecraft/client/gui/screen/ConfirmChatLinkScr
 	FIELD field_3047 copy Ljava/lang/String;
 	FIELD field_3048 link Ljava/lang/String;
 	FIELD field_3049 drawWarning Z
+	METHOD <init> (Lnet/minecraft/class_2292;Ljava/lang/String;IZ)V
+		ARG 1 parent
+		ARG 2 link
+		ARG 3 id
+		ARG 4 trusted
 	METHOD method_2706 copyToClipboard ()V
+	METHOD method_2707 noWarning ()V

--- a/mappings/net/minecraft/client/gui/screen/ConfirmationScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ConfirmationScreen.mapping
@@ -1,3 +1,14 @@
 CLASS net/minecraft/class_2699 net/minecraft/client/gui/screen/ConfirmationScreen
+	FIELD field_11885 parent Lnet/minecraft/class_2292;
 	FIELD field_11886 conferYes Ljava/lang/String;
 	FIELD field_11887 confermNo Ljava/lang/String;
+	FIELD field_11888 id I
+	FIELD field_11889 screenType Lnet/minecraft/class_2700;
+	FIELD field_11890 line1 Ljava/lang/String;
+	FIELD field_11891 line2 Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_2700;Ljava/lang/String;Ljava/lang/String;I)V
+		ARG 1 parent
+		ARG 2 type
+		ARG 3 line1
+		ARG 4 line2
+		ARG 5 id

--- a/mappings/net/minecraft/client/gui/screen/CreditsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CreditsScreen.mapping
@@ -1,7 +1,9 @@
 CLASS net/minecraft/class_767 net/minecraft/client/gui/screen/CreditsScreen
+	FIELD field_10102 creditTextLines Ljava/util/List;
 	FIELD field_3294 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_3295 MINECRAFT_TEXTURE Lnet/minecraft/class_1605;
 	FIELD field_3296 VIGNETTE_TEXTURE Lnet/minecraft/class_1605;
+	FIELD field_3297 ticksOpen I
 	FIELD field_3299 creditsHeight I
 	FIELD field_3300 speed F
 	METHOD method_2850 close ()V

--- a/mappings/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/CustomizeFlatLevelScreen.mapping
@@ -1,14 +1,30 @@
 CLASS net/minecraft/class_729 net/minecraft/client/gui/screen/CustomizeFlatLevelScreen
+	FIELD field_10077 itemRenderer Lnet/minecraft/class_2358;
 	FIELD field_3067 parent Lnet/minecraft/class_731;
 	FIELD field_3068 helper Lnet/minecraft/class_473;
 	FIELD field_3069 title Ljava/lang/String;
 	FIELD field_3070 tileText Ljava/lang/String;
 	FIELD field_3071 heightText Ljava/lang/String;
+	FIELD field_3072 customizeFlatLevelListWidget Lnet/minecraft/class_730;
 	FIELD field_3073 addLayer Lnet/minecraft/class_685;
 	FIELD field_3074 editLayer Lnet/minecraft/class_685;
 	FIELD field_3075 removeLayer Lnet/minecraft/class_685;
 	METHOD <init> (Lnet/minecraft/class_731;Ljava/lang/String;)V
 		ARG 1 parent
+		ARG 2 preset
 	METHOD method_2718 getConfigString ()Ljava/lang/String;
+	METHOD method_2719 getZOffset1 (Lnet/minecraft/class_729;)F
+		ARG 0 customizeFlatLevelScreen
 	METHOD method_2720 setConfigString (Ljava/lang/String;)V
 		ARG 1 config
+	METHOD method_2721 getZOffset2 (Lnet/minecraft/class_729;)F
+		ARG 0 customizeFlatLevelScreen
+	METHOD method_2722 getZOffset3 (Lnet/minecraft/class_729;)F
+		ARG 0 customizeFlatLevelScreen
+	METHOD method_2723 getZOffset4 (Lnet/minecraft/class_729;)F
+		ARG 0 customizeFlatLevelScreen
+	METHOD method_2724 getHelper (Lnet/minecraft/class_729;)Lnet/minecraft/class_473;
+		ARG 0 customizeFlatLevelScreen
+	METHOD method_2725 setActive ()V
+	METHOD method_2726 isActive ()Z
+	METHOD method_9219 getItemRenderer ()Lnet/minecraft/class_2358;

--- a/mappings/net/minecraft/client/gui/screen/DisconnectedScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/DisconnectedScreen.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_739 net/minecraft/client/gui/screen/DisconnectedScreen
+	FIELD field_10078 textLines Ljava/util/List;
 	FIELD field_3147 name Ljava/lang/String;
 	FIELD field_3148 reason Lnet/minecraft/class_1444;
 	FIELD field_3150 parent Lnet/minecraft/class_2292;

--- a/mappings/net/minecraft/client/gui/screen/InnerEntityStatsListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/InnerEntityStatsListWidget.mapping
@@ -1,1 +1,5 @@
 CLASS net/minecraft/class_2298 net/minecraft/client/gui/screen/InnerEntityStatsListWidget
+	FIELD field_10115 parent Lnet/minecraft/class_770;
+	FIELD field_10116 entries Ljava/util/List;
+	METHOD <init> (Lnet/minecraft/class_770;)V
+		ARG 1 parent

--- a/mappings/net/minecraft/client/gui/screen/PresetsListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/PresetsListWidget.mapping
@@ -7,11 +7,11 @@ CLASS net/minecraft/class_750 net/minecraft/client/gui/screen/PresetsListWidget
 		ARG 1 x
 		ARG 2 y
 		ARG 3 item
-	METHOD method_2779 (IIII)V
+	METHOD method_2779 render (IIII)V
 		ARG 1 x
 		ARG 2 y
 		ARG 3 u
 		ARG 4 v
-	METHOD method_2780 (II)V
+	METHOD method_2780 render (II)V
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/client/gui/screen/PresetsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/PresetsScreen.mapping
@@ -11,11 +11,24 @@ CLASS net/minecraft/class_748 net/minecraft/client/gui/screen/PresetsScreen
 	METHOD <init> (Lnet/minecraft/class_729;)V
 		ARG 1 parent
 	METHOD method_2766 activateSelectButtonIfPresetSelected ()V
+	METHOD method_2767 getZOffset1 (Lnet/minecraft/class_748;)F
+		ARG 0 presetScreen
 	METHOD method_2770 addRedstonePreset (Ljava/lang/String;Lnet/minecraft/class_2054;Lnet/minecraft/class_113;[Lnet/minecraft/class_475;)V
 		ARG 0 name
 		ARG 1 icon
 		ARG 2 iconDamage
 		ARG 3 layers
+	METHOD method_2771 getZOffset2 (Lnet/minecraft/class_748;)F
+		ARG 0 presetScreen
+	METHOD method_2772 getZOffset3 (Lnet/minecraft/class_748;)F
+		ARG 0 presetScreen
+	METHOD method_2773 getZOffset4 (Lnet/minecraft/class_748;)F
+		ARG 0 presetScreen
+	METHOD method_2774 getListWidget (Lnet/minecraft/class_748;)Lnet/minecraft/class_750;
+		ARG 0 presetScreen
+	METHOD method_2775 getPresetsList ()Ljava/util/List;
+	METHOD method_2776 getField (Lnet/minecraft/class_748;)Lnet/minecraft/class_689;
+		ARG 0 presetScreen
 	METHOD method_2777 isPresetSelected ()Z
 		COMMENT Returns true if any preset is selected
 	METHOD method_9220 addFlatWorldPreset (Ljava/lang/String;Lnet/minecraft/class_2054;Lnet/minecraft/class_113;Ljava/util/List;[Lnet/minecraft/class_475;)V
@@ -24,3 +37,4 @@ CLASS net/minecraft/class_748 net/minecraft/client/gui/screen/PresetsScreen
 		ARG 2 biome
 		ARG 3 biomesAndStructures
 		ARG 4 layers
+	METHOD method_9221 getPresetsItemRenderer ()Lnet/minecraft/class_2358;

--- a/mappings/net/minecraft/client/gui/screen/Screen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/Screen.mapping
@@ -5,7 +5,7 @@ CLASS net/minecraft/class_2292 net/minecraft/client/gui/screen/Screen
 	FIELD field_10091 multiTouch I
 	FIELD field_10092 itemRenderer Lnet/minecraft/class_2358;
 	FIELD field_10093 client Lnet/minecraft/class_669;
-	FIELD field_10094 width I
+	FIELD field_10094 titleWidth I
 	FIELD field_10095 height I
 	FIELD field_10096 buttons Ljava/util/List;
 	FIELD field_10097 labels Ljava/util/List;

--- a/mappings/net/minecraft/client/gui/screen/SoundsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/SoundsScreen.mapping
@@ -6,3 +6,7 @@ CLASS net/minecraft/class_762 net/minecraft/client/gui/screen/SoundsScreen
 	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_2277;)V
 		ARG 1 parent
 		ARG 2 options
+	METHOD method_2841 getOptions (Lnet/minecraft/class_762;)Lnet/minecraft/class_2277;
+		ARG 0 soundScreen
+	METHOD method_2842 getVolume (Lnet/minecraft/class_1306;)Ljava/lang/String;
+		ARG 1 soundCatecory

--- a/mappings/net/minecraft/client/gui/screen/TitleScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/TitleScreen.mapping
@@ -1,19 +1,28 @@
 CLASS net/minecraft/class_765 net/minecraft/client/gui/screen/TitleScreen
 	FIELD field_12078 realmsButton Lnet/minecraft/class_685;
+	FIELD field_12079 mcoAvailabilityCheckerCount Ljava/util/concurrent/atomic/AtomicInteger;
+	FIELD field_12080 realmsEnabled Z
 	FIELD field_12081 isRealmsChecked Z
 	FIELD field_12082 mcoEnabled Z
 	FIELD field_3262 SPLASHES Lnet/minecraft/class_1605;
 	FIELD field_3263 MINECRAFT_TITLE_TEXTURE Lnet/minecraft/class_1605;
 	FIELD field_3264 PANORAMA_ARRAY [Lnet/minecraft/class_1605;
+	FIELD field_3265 warningTextWidth I
+	FIELD field_3266 outdatedGpuTextWidth I
+	FIELD field_3267 x1 I
+	FIELD field_3268 y1 I
+	FIELD field_3269 x2 I
+	FIELD field_3270 y2 I
 	FIELD field_3271 backgroundTexture Lnet/minecraft/class_1605;
 	FIELD field_3275 MORE_INFO Ljava/lang/String;
 	FIELD field_3277 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_3278 RANDOM Ljava/util/Random;
 	FIELD field_3279 randomFloat F
-	FIELD field_3280 splash Ljava/lang/String;
+	FIELD field_3280 splashText Ljava/lang/String;
 	FIELD field_3281 buttonResetDemo Lnet/minecraft/class_685;
 	FIELD field_3282 time I
 	FIELD field_3283 defualtBackgroundImage Lnet/minecraft/class_1219;
+	FIELD field_3285 threadedLock Ljava/lang/Object;
 	FIELD field_3286 outdatedGpuWarning Ljava/lang/String;
 	FIELD field_3287 warningInfo Ljava/lang/String;
 	FIELD field_3288 warningInfoLink Ljava/lang/String;
@@ -27,7 +36,19 @@ CLASS net/minecraft/class_765 net/minecraft/client/gui/screen/TitleScreen
 	METHOD method_11212 checkIsRealmsAvailable ()V
 	METHOD method_11213 setRealmsButtonVisible ()V
 	METHOD method_11214 openRealmsScreen ()V
+	METHOD method_2844 drawBackgroundImage (F)V
+		ARG 1 tickDelta
 	METHOD method_2845 initWidgetsNormal (II)V
+		ARG 1 height
+		ARG 2 offset
+	METHOD method_2846 drawBackgroundBase (IIF)V
+		ARG 1 mouseX
+		ARG 2 mouseY
+		ARG 3 tickdelta
 	METHOD method_2847 initWidgetsDemo (II)V
 		ARG 1 y
 		ARG 2 spacingY
+	METHOD method_2848 drawBackground (IIF)V
+		ARG 1 mouseX
+		ARG 2 mouseY
+		ARG 3 tickDelta

--- a/mappings/net/minecraft/client/gui/screen/VideoOptionsScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/VideoOptionsScreen.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_766 net/minecraft/client/gui/screen/VideoOptionsScreen
 	FIELD field_3289 title Ljava/lang/String;
 	FIELD field_3290 parent Lnet/minecraft/class_2292;
 	FIELD field_3291 options Lnet/minecraft/class_2277;
+	FIELD field_3292 listWidget Lnet/minecraft/class_698;
+	FIELD field_3293 VIDEO_OPTIONS [Lnet/minecraft/class_2280;
 	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_2277;)V
 		ARG 1 parent
 		ARG 2 options

--- a/mappings/net/minecraft/client/gui/screen/ingame/CreativeInventoryScreen.mapping
+++ b/mappings/net/minecraft/client/gui/screen/ingame/CreativeInventoryScreen.mapping
@@ -9,12 +9,15 @@ CLASS net/minecraft/class_795 net/minecraft/client/gui/screen/ingame/CreativeInv
 	FIELD field_3469 selectedTab I
 	FIELD field_3470 scrollPosition F
 	FIELD field_3471 hasScrollBar Z
+	FIELD field_3472 isMouseButtonDown Z
 	METHOD <init> (Lnet/minecraft/class_2674;)V
 		ARG 1 player
 	METHOD method_2927 renderTabIcon (Lnet/minecraft/class_2029;)V
 		ARG 1 group
-	METHOD method_2928 (Lnet/minecraft/class_2029;II)Z
+	METHOD method_2928 isInRow (Lnet/minecraft/class_2029;II)Z
 		ARG 1 group
+		ARG 2 x
+		ARG 3 z
 	METHOD method_2929 setSelectedTab (Lnet/minecraft/class_2029;)V
 		ARG 1 group
 	METHOD method_2930 renderTabTooltipIfHovered (Lnet/minecraft/class_2029;II)Z
@@ -22,5 +25,6 @@ CLASS net/minecraft/class_795 net/minecraft/client/gui/screen/ingame/CreativeInv
 		ARG 2 mouseX
 		ARG 3 mouseY
 	METHOD method_2931 getSelectedTab ()I
+	METHOD method_2932 getInventory ()Lnet/minecraft/class_1727;
 	METHOD method_2933 search ()V
 	METHOD method_2934 hasScrollbar ()Z

--- a/mappings/net/minecraft/client/gui/screen/resourcepack/AbstractResourcePackEntryWidget.mapping
+++ b/mappings/net/minecraft/client/gui/screen/resourcepack/AbstractResourcePackEntryWidget.mapping
@@ -7,5 +7,8 @@ CLASS net/minecraft/class_2305 net/minecraft/client/gui/screen/resourcepack/Abst
 	METHOD method_2978 getDescription ()Ljava/lang/String;
 	METHOD method_2979 getName ()Ljava/lang/String;
 	METHOD method_2980 bindIcon ()V
+	METHOD method_9254 hasResourcePack ()Z
 	METHOD method_9255 isNotNamed ()Z
 	METHOD method_9256 isNamed ()Z
+	METHOD method_9257 moveDown ()Z
+	METHOD method_9258 moveUp ()Z

--- a/mappings/net/minecraft/client/gui/widget/ListWidget.mapping
+++ b/mappings/net/minecraft/client/gui/widget/ListWidget.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_713 net/minecraft/client/gui/widget/ListWidget
 	FIELD field_10057 centerAlongY Z
 	FIELD field_10058 client Lnet/minecraft/class_669;
 	FIELD field_10059 mouseYStart F
+	FIELD field_10060 pos I
 	FIELD field_11806 mouseX I
 	FIELD field_11807 mouseY I
 	FIELD field_2992 width I
@@ -13,6 +14,7 @@ CLASS net/minecraft/class_713 net/minecraft/client/gui/widget/ListWidget
 	FIELD field_2998 entryHeight I
 	FIELD field_3003 scrollSpeedMultiplier F
 	FIELD field_3004 scrollAmount F
+	FIELD field_3006 time J
 	FIELD field_3008 renderSelectionBox Z
 	FIELD field_3009 renderHeader Z
 	FIELD field_3010 headerHeight I
@@ -29,6 +31,9 @@ CLASS net/minecraft/class_713 net/minecraft/client/gui/widget/ListWidget
 	METHOD method_2628 renderBackground ()V
 	METHOD method_2629 isEntrySelected (I)Z
 		ARG 1 index
+	METHOD method_2630 render (II)V
+		ARG 1 x
+		ARG 2 y
 	METHOD method_2633 updateBounds (IIII)V
 		ARG 1 right
 		ARG 2 height

--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -7,9 +7,9 @@ CLASS net/minecraft/class_900 net/minecraft/client/model/ModelPart
 	FIELD field_3932 pivotX F
 	FIELD field_3933 pivotY F
 	FIELD field_3934 pivotZ F
-	FIELD field_3935 posX F
-	FIELD field_3936 posY F
-	FIELD field_3937 posZ F
+	FIELD field_3935 rotationX F
+	FIELD field_3936 rotationY F
+	FIELD field_3937 rotationZ F
 	FIELD field_3939 visible Z
 	FIELD field_3940 invisible Z
 	FIELD field_3943 name Ljava/lang/String;

--- a/mappings/net/minecraft/client/model/ModelPart.mapping
+++ b/mappings/net/minecraft/client/model/ModelPart.mapping
@@ -64,12 +64,12 @@ CLASS net/minecraft/class_900 net/minecraft/client/model/ModelPart
 		ARG 5 sizeX
 		ARG 6 sizeY
 		ARG 7 sizeZ
-	METHOD method_3104 (F)V
+	METHOD method_3104 renderRotation (F)V
 		ARG 1 scale
 	METHOD method_3105 setTextureSize (II)Lnet/minecraft/class_900;
 		ARG 1 width
 		ARG 2 height
-	METHOD method_3106 (F)V
+	METHOD method_3106 modifyRender (F)V
 		ARG 1 scale
 	METHOD method_3107 initGlStuff (F)V
 		ARG 1 scale

--- a/mappings/net/minecraft/client/realms/ServerListTimerTask.mapping
+++ b/mappings/net/minecraft/client/realms/ServerListTimerTask.mapping
@@ -3,4 +3,10 @@ CLASS net/minecraft/class_2720 net/minecraft/client/realms/ServerListTimerTask
 	FIELD field_12013 client Lnet/minecraft/class_2730;
 	METHOD <init> (Lnet/minecraft/class_2719;)V
 		ARG 1 serverList
+	METHOD <init> (Lnet/minecraft/class_2719;Lnet/minecraft/class_2424;)V
+		ARG 1 serverList
 	METHOD method_11143 getServerList ()V
+	METHOD method_11144 sortServerList (Ljava/util/List;)V
+		ARG 1 serverList
+	METHOD method_11145 setServerList ()V
+	METHOD method_11146 setSubscriptionStatis ()V

--- a/mappings/net/minecraft/client/realms/ServerListTimerTask.mapping
+++ b/mappings/net/minecraft/client/realms/ServerListTimerTask.mapping
@@ -9,4 +9,4 @@ CLASS net/minecraft/class_2720 net/minecraft/client/realms/ServerListTimerTask
 	METHOD method_11144 sortServerList (Ljava/util/List;)V
 		ARG 1 serverList
 	METHOD method_11145 setServerList ()V
-	METHOD method_11146 setSubscriptionStatis ()V
+	METHOD method_11146 setSubscriptionStatus ()V

--- a/mappings/net/minecraft/client/realms/dto/RealmsServer.mapping
+++ b/mappings/net/minecraft/client/realms/dto/RealmsServer.mapping
@@ -10,7 +10,10 @@ CLASS net/minecraft/class_2739 net/minecraft/client/realms/dto/RealmsServer
 	FIELD field_12107 difficulty I
 	FIELD field_12108 gameMode I
 	FIELD field_12109 daysLeft I
+	FIELD field_12110 serverId I
+	FIELD field_12111 serverName Ljava/lang/String;
 	FIELD field_12112 playerCount Ljava/lang/String;
+	FIELD field_12113 pinged Z
 	METHOD equals (Ljava/lang/Object;)Z
 		ARG 1 object
 	METHOD method_11267 getMotd ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/realms/gui/screen/AbstractRealmsWorldScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/AbstractRealmsWorldScreen.mapping
@@ -2,6 +2,8 @@ CLASS net/minecraft/class_2707 net/minecraft/client/realms/gui/screen/AbstractRe
 	FIELD field_11941 client Lnet/minecraft/class_669;
 	FIELD field_11943 mouseX I
 	FIELD field_11944 mouseY I
+	FIELD field_11945 width I
+	FIELD field_11946 height I
 	FIELD field_11953 lastClickTime J
 	METHOD <init> (Lnet/minecraft/class_669;IIIII)V
 		ARG 1 client

--- a/mappings/net/minecraft/client/realms/gui/screen/EditRealmsWorldScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/EditRealmsWorldScreen.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2697 net/minecraft/client/realms/gui/screen/EditWorldScreen
+CLASS net/minecraft/class_2697 net/minecraft/client/realms/gui/screen/EditRealmsWorldScreen
 	FIELD field_11864 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_11865 configureRealmsWorldScreen Lnet/minecraft/class_2292;
 	FIELD field_11866 realmsMainScreen Lnet/minecraft/class_2292;
@@ -6,6 +6,9 @@ CLASS net/minecraft/class_2697 net/minecraft/client/realms/gui/screen/EditWorldS
 	FIELD field_11868 serverNameTextField Lnet/minecraft/class_689;
 	FIELD field_11869 server Lnet/minecraft/class_2739;
 	FIELD field_11870 doneButton Lnet/minecraft/class_685;
+	FIELD field_11871 width I
+	FIELD field_11872 buttonLeft I
+	FIELD field_11873 buttonRight I
 	FIELD field_11874 editWorldScreenHelper Lnet/minecraft/class_2713;
 	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_2292;Lnet/minecraft/class_2739;)V
 		ARG 1 screen1

--- a/mappings/net/minecraft/client/realms/gui/screen/InviteScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/InviteScreen.mapping
@@ -4,6 +4,10 @@ CLASS net/minecraft/class_2698 net/minecraft/client/realms/gui/screen/InviteScre
 	FIELD field_11877 realmsServer Lnet/minecraft/class_2739;
 	FIELD field_11878 screen Lnet/minecraft/class_2292;
 	FIELD field_11879 configureWorldScreen Lnet/minecraft/class_2692;
+	FIELD field_11880 I
+		COMMENT unused in 1.7.2
+	FIELD field_11881 I
+		COMMENT unused in 1.7.2
 	FIELD field_11882 couldNotInviteError Ljava/lang/String;
 	FIELD field_11883 error Ljava/lang/String;
 	FIELD field_11884 isError Z

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsListWidget.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsListWidget.mapping
@@ -27,6 +27,9 @@ CLASS net/minecraft/class_2703 net/minecraft/client/realms/gui/screen/RealmsList
 		ARG 5 bottom
 		ARG 6 entryHeight
 	METHOD method_11003 getInviteListSize ()I
+	METHOD method_11005 (II)V
+		ARG 1 x
+		ARG 2 y
 	METHOD method_11006 render (IIF)V
 		ARG 1 mouseX
 		ARG 2 mouseY
@@ -47,6 +50,9 @@ CLASS net/minecraft/class_2703 net/minecraft/client/realms/gui/screen/RealmsList
 	METHOD method_11011 buttonClicked (Lnet/minecraft/class_685;)V
 		ARG 1 buttonWidget
 	METHOD method_11012 getListSize ()I
+	METHOD method_11014 (II)V
+		ARG 1 x
+		ARG 2 y
 	METHOD method_11015 (IIII)V
 		ARG 1 top
 		ARG 2 bottom
@@ -55,3 +61,4 @@ CLASS net/minecraft/class_2703 net/minecraft/client/realms/gui/screen/RealmsList
 	METHOD method_11016 renderBackground ()V
 	METHOD method_11017 getMaxScroll ()I
 	METHOD method_11018 getScrollbarPosition ()I
+	METHOD method_11019 setScrollAmount ()V

--- a/mappings/net/minecraft/client/render/TextRenderer.mapping
+++ b/mappings/net/minecraft/client/render/TextRenderer.mapping
@@ -2,24 +2,57 @@ CLASS net/minecraft/class_679 net/minecraft/client/render/TextRenderer
 	FIELD field_2815 fontHeight I
 	FIELD field_2816 random Ljava/util/Random;
 	FIELD field_2817 PAGES [Lnet/minecraft/class_1605;
+	FIELD field_2818 specialCharacterWidth [I
+	FIELD field_2819 glyphSizes [B
+	FIELD field_2820 colors [I
 	FIELD field_2821 fontTexture Lnet/minecraft/class_1605;
 	FIELD field_2822 textureManager Lnet/minecraft/class_1232;
+	FIELD field_2823 xPos F
+	FIELD field_2824 zPos F
+	FIELD field_2825 unicode Z
 	FIELD field_2826 rightToLeft Z
+	FIELD field_2827 r F
+		COMMENT The amount of red in the texts (r, g, b, a) color.
+	FIELD field_2828 g F
+		COMMENT The amount of blue in the texts (r, g, b, a) color.
+	FIELD field_2829 b F
+		COMMENT The amount of green in the texts (r, g, b, a) color.
+	FIELD field_2830 a F
+		COMMENT The amount of alpha in the texts (r, g, b, a) color.
+	FIELD field_2831 color I
+	FIELD field_2832 obfuscated Z
+	FIELD field_2833 bold Z
+	FIELD field_2834 reset Z
+	FIELD field_2835 underline Z
+	FIELD field_2836 strikethrough Z
 	METHOD <init> (Lnet/minecraft/class_2277;Lnet/minecraft/class_1605;Lnet/minecraft/class_1232;Z)V
 		ARG 1 options
 		ARG 2 fontTexture
 		ARG 3 textureManager
+		ARG 4 unicode
+	METHOD method_2381 getUnicode ()Z
+	METHOD method_2382 getSpecialCharacterWidth (C)I
+		ARG 1 character
+	METHOD method_2383 renderText (ICZ)F
+		ARG 1 formattingChar
+		ARG 2 unicodeChar
+		ARG 3 reset
 	METHOD method_2384 getFontPage (I)Lnet/minecraft/class_1605;
 		ARG 1 page
+	METHOD method_2385 renderBasicText (IZ)F
+		ARG 1 formattingChar
+		ARG 2 reset
 	METHOD method_2386 getStringWidth (Ljava/lang/String;)I
 		ARG 1 text
 	METHOD method_2387 drawWithShadow (Ljava/lang/String;III)I
 		ARG 1 text
+		ARG 2 x
+		ARG 3 y
 		ARG 4 color
 	METHOD method_2389 trimToWidth (Ljava/lang/String;I)Ljava/lang/String;
 		ARG 1 text
 		ARG 2 width
-	METHOD method_2390 draw (Ljava/lang/String;III)I
+	METHOD method_2390 drawWithoutShadow (Ljava/lang/String;III)I
 		ARG 1 text
 		ARG 2 x
 		ARG 3 y
@@ -30,24 +63,102 @@ CLASS net/minecraft/class_679 net/minecraft/client/render/TextRenderer
 		ARG 3 y
 		ARG 4 maxWidth
 		ARG 5 color
+	METHOD method_2392 drawLayer (Ljava/lang/String;IIIIZ)I
+		ARG 1 line
+		ARG 2 x
+		ARG 3 y
+		ARG 4 maxWidth
+		ARG 5 color
+		ARG 6 colored
+	METHOD method_2393 drawText (Ljava/lang/String;IIIZ)V
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 maxWidth
+		ARG 5 color
 	METHOD method_2394 trimToWidth (Ljava/lang/String;IZ)Ljava/lang/String;
+		ARG 1 text
+		ARG 2 width
+		ARG 3 shouldInverse
+	METHOD method_2395 drawLine (Ljava/lang/String;Z)V
+		COMMENT 0 1 2 3 4 5 6 7 8 9 a  b  c  d  e  f  k  l  m  n  o  r
+		COMMENT 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21
+		ARG 1 text
+		ARG 2 hasShadow
+	METHOD method_2396 setUnicode (Z)V
+		ARG 1 unicode
 	METHOD method_2397 isRightToLeft ()Z
+	METHOD method_2399 renderUnicodeText (CZ)F
+		ARG 1 unicodeCharacter
+		ARG 2 reset
 	METHOD method_2400 bindFontPageTexture (I)V
 		ARG 1 page
+	METHOD method_2401 getAllFormatCharacters (Ljava/lang/String;)Ljava/lang/String;
+		COMMENT Strips all non formatting characters from a string and returns an string containing only chained formatting characters.
+		ARG 0 text
 	METHOD method_2402 drawLayer (Ljava/lang/String;IIIZ)I
 		ARG 1 text
+		ARG 2 x
+		ARG 3 y
 		ARG 4 color
+		ARG 5 colored
+	METHOD method_2403 getTextBoxHeight (Ljava/lang/String;I)I
+		ARG 1 text
+		ARG 2 lineLength
 	METHOD method_2404 setRightToLeft (Z)V
 		ARG 1 rightToLeft
 	METHOD method_2405 init ()V
+	METHOD method_2406 isColorCharacter (C)Z
+		COMMENT Checks if a certain formatting character is a color. The different colors are:
+		COMMENT <ul>
+		COMMENT <li><b>0:</b> <span style="color:#000000";>black</span></li>
+		COMMENT <li><b>1:</b> <span style="color:#0000AA";>dark blue</span></li>
+		COMMENT <li><b>2:</b> <span style="color:#00AA00";>dark green</span></li>
+		COMMENT <li><b>3:</b> <span style="color:#00AAAA";>dark aqua</span></li>
+		COMMENT <li><b>4:</b> <span style="color:#AA0000";>dark red</span></li>
+		COMMENT <li><b>5:</b> <span style="color:#AA00AA";>dark purple</span></li>
+		COMMENT <li><b>6:</b> <span style="color:#FFAA00";>gold</span></li>
+		COMMENT <li><b>7:</b> <span style="color:#AAAAAA";>gray</span></li>
+		COMMENT <li><b>8:</b> <span style="color:#555555";>dark gray</span></li>
+		COMMENT <li><b>9:</b> <span style="color:#5555FF";>blue</span></li>
+		COMMENT <li><b>a/A:</b> <span style="color:#55FF55";>green</span></li>
+		COMMENT <li><b>b/B:</b> <span style="color:#55FFFF";>aqua</span></li>
+		COMMENT <li><b>c/C:</b> <span style="color:#FF5555";>red</span></li>
+		COMMENT <li><b>d/D:</b> <span style="color:#FF55FF";>light_purple</span></li>
+		COMMENT <li><b>e/E:</b> <span style="color:#FFFF55";>yellow</span></li>
+		COMMENT <li><b>f/F:</b> <span style="color:#FFFFFF";>white</span></li>
+		COMMENT <li><b>g/G:</b> <span style="color:#DDD605";>minecoin gold</span></li>
+		COMMENT </ul>
+		ARG 0 formatChar
 	METHOD method_2407 mirror (Ljava/lang/String;)Ljava/lang/String;
 		ARG 1 text
 	METHOD method_2408 wrapLines (Ljava/lang/String;I)Ljava/util/List;
+		ARG 1 text
+		ARG 2 lineLength
+	METHOD method_2409 getGlyphSizes ()V
+	METHOD method_2410 isFormattinCharacter (C)Z
+		COMMENT Checks the type of formatting character.
+		COMMENT <ul>
+		COMMENT <li><b>k:</b> <span style="color:#000000";>obfuscated</span></li>
+		COMMENT <li><b>l:</b> <span style="color:#000000";><b>bold</b></span></li>
+		COMMENT <li><b>m:</b> <span style="color:#000000";><strike>strikethrough</strike></span></li>
+		COMMENT <li><b>n:</b> <span style="color:#000000";><u>underline</u></span></li>
+		COMMENT <li><b>o:</b> <span style="color:#000000";><i>italic</i></span></li>
+		COMMENT <li><b>r:</b> <span style="color:#000000";>reset</span></li>
+		COMMENT </ul>
+		ARG 0 formatChar
 	METHOD method_2411 trimEndNewlines (Ljava/lang/String;)Ljava/lang/String;
 		ARG 1 text
 	METHOD method_2412 wrapStringToWidth (Ljava/lang/String;I)Ljava/lang/String;
 		ARG 1 text
 		ARG 2 width
+	METHOD method_2413 reset ()V
 	METHOD method_2414 getCharacterCountForWidth (Ljava/lang/String;I)I
 		ARG 1 text
 		ARG 2 offset
+	METHOD method_9189 draw (Ljava/lang/String;IIIZ)I
+		ARG 1 text
+		ARG 2 x
+		ARG 3 y
+		ARG 4 color
+		ARG 5 shadow

--- a/mappings/net/minecraft/client/render/entity/ArmoredEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/ArmoredEntityRenderer.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_2356 net/minecraft/client/render/entity/ArmoredEntityRenderer
 	FIELD field_10647 model Lnet/minecraft/class_866;
+	FIELD field_10648 F
+		COMMENT Unused field.
 	FIELD field_10649 model1 Lnet/minecraft/class_866;
 	FIELD field_10650 model2 Lnet/minecraft/class_866;
 	FIELD field_10651 ARMOR_TEXTURE_MAP Ljava/util/Map;
@@ -10,7 +12,6 @@ CLASS net/minecraft/class_2356 net/minecraft/client/render/entity/ArmoredEntityR
 	METHOD <init> (Lnet/minecraft/class_866;FF)V
 		ARG 1 model
 		ARG 2 shadowSize
-		ARG 3 unused
 	METHOD method_9618 getArmorTexture (Lnet/minecraft/class_2012;I)Lnet/minecraft/class_1605;
 		ARG 0 armorItem
 		ARG 1 layer

--- a/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/EntityRenderer.mapping
@@ -1,6 +1,8 @@
 CLASS net/minecraft/class_1136 net/minecraft/client/render/entity/EntityRenderer
 	FIELD field_10640 dispatcher Lnet/minecraft/class_1135;
 	FIELD field_10641 blockRenderer Lnet/minecraft/class_2336;
+	FIELD field_10642 Z
+		COMMENT Unused field.
 	FIELD field_4839 SHADOW_TEXTURE Lnet/minecraft/class_1605;
 	FIELD field_4841 shadowSize F
 	FIELD field_4842 shadowDarkness F

--- a/mappings/net/minecraft/client/render/entity/LightningBoltEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/LightningBoltEntityRenderer.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2365 net/minecraft/client/render/entity/LightningBoltEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_896 net/minecraft/client/render/entity/model/AbstractZombieModel
+	METHOD <init> (FZ)V
+		ARG 1 reduction
+		ARG 2 pivot

--- a/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/AbstractZombieModel.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_896 net/minecraft/client/render/entity/model/AbstractZombieModel
-	METHOD <init> (FZ)V
-		ARG 1 reduction
-		ARG 2 pivot

--- a/mappings/net/minecraft/client/render/entity/model/BatEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BatEntityModel.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_851 net/minecraft/client/render/entity/model/BatEntityModel
+	FIELD field_3695 head Lnet/minecraft/class_900;
+	FIELD field_3696 body Lnet/minecraft/class_900;
+	FIELD field_3697 rightWing Lnet/minecraft/class_900;
+	FIELD field_3698 leftWing Lnet/minecraft/class_900;
+	FIELD field_3699 rightWingTip Lnet/minecraft/class_900;
+	FIELD field_3700 leftWingTip Lnet/minecraft/class_900;
+	METHOD method_9271 maxHands ()I

--- a/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BiPedModel
-	FIELD field_10176 deadmausEars Lnet/minecraft/class_900;
+	FIELD field_10176 deadmau5Ears Lnet/minecraft/class_900;
 	FIELD field_10177 cape Lnet/minecraft/class_900;
 	FIELD field_10178 leftHandItemId I
 	FIELD field_10179 rightHandItemId I
@@ -21,5 +21,5 @@ CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BiPedMode
 		ARG 4 textureHeight
 	METHOD method_3050 renderCape (F)V
 		ARG 1 scale
-	METHOD method_9273 renderDeadmausEars (F)V
+	METHOD method_9273 renderDeadmau5Ears (F)V
 		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BiPedModel.mapping
@@ -1,6 +1,25 @@
 CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BiPedModel
-	FIELD field_10179 holdingItem I
-	FIELD field_10180 isSneaking Z
+	FIELD field_10176 deadmausEars Lnet/minecraft/class_900;
+	FIELD field_10177 cape Lnet/minecraft/class_900;
+	FIELD field_10178 leftHandItemId I
+	FIELD field_10179 rightHandItemId I
+	FIELD field_10180 sneaking Z
+	FIELD field_10181 aimingBow Z
+	FIELD field_3781 head Lnet/minecraft/class_900;
+	FIELD field_3782 hat Lnet/minecraft/class_900;
+	FIELD field_3783 body Lnet/minecraft/class_900;
+	FIELD field_3784 rightArm Lnet/minecraft/class_900;
+	FIELD field_3785 leftArm Lnet/minecraft/class_900;
+	FIELD field_3786 rightLeg Lnet/minecraft/class_900;
+	FIELD field_3787 leftLeg Lnet/minecraft/class_900;
+	METHOD <init> (F)V
+		ARG 1 reduction
 	METHOD <init> (FFII)V
 		ARG 1 reduction
 		ARG 2 pivotPoint
+		ARG 3 textureWidth
+		ARG 4 textureHeight
+	METHOD method_3050 renderCape (F)V
+		ARG 1 scale
+	METHOD method_9273 renderDeadmausEars (F)V
+		ARG 1 scale

--- a/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BiPedModel
+CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BipedEntityModel
 	FIELD field_10176 deadmau5Ears Lnet/minecraft/class_900;
 	FIELD field_10177 cape Lnet/minecraft/class_900;
 	FIELD field_10178 leftHandItemId I

--- a/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BipedEntityModel.mapping
@@ -1,4 +1,19 @@
 CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BipedEntityModel
+	COMMENT This class is used for some, but not all bipedal mobs. Entities that use this class or extend from it are:
+	COMMENT <ul>
+	COMMENT <li>Zombie/Zombie Villager</li>
+	COMMENT <li>Player</li>
+	COMMENT <li>Skelleto</li>
+	COMMENT </ul>
+	COMMENT
+	COMMENT Mobs that don't use this class but are bipedal:
+	COMMENT <ul>
+	COMMENT <li>Chicken</li>
+	COMMENT <li>Witch</li>
+	COMMENT <li>Villager</li>
+	COMMENT <li>Iron Golem</li>
+	COMMENT <li>Wither Skelleton</li>
+	COMMENT </ul>
 	FIELD field_10176 deadmau5Ears Lnet/minecraft/class_900;
 	FIELD field_10177 cape Lnet/minecraft/class_900;
 	FIELD field_10178 leftHandItemId I

--- a/mappings/net/minecraft/client/render/entity/model/BlazeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BlazeEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_852 net/minecraft/client/render/entity/model/BlazeEntityModel
+	FIELD field_3701 rods [Lnet/minecraft/class_900;
+	FIELD field_3702 head Lnet/minecraft/class_900;
+	METHOD method_9272 getNumberOfTopRods ()I

--- a/mappings/net/minecraft/client/render/entity/model/BoatEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BoatEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_853 net/minecraft/client/render/entity/model/BoatEntityModel
+	FIELD field_3703 parts [Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/BookEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BookEntityModel.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_854 net/minecraft/client/render/entity/model/BookModel
+CLASS net/minecraft/class_854 net/minecraft/client/render/entity/model/BookEntityModel
 	FIELD field_3704 leftCover Lnet/minecraft/class_900;
 	FIELD field_3705 rightCover Lnet/minecraft/class_900;
 	FIELD field_3706 leftPage Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/BookModel.mapping
@@ -1,1 +1,8 @@
 CLASS net/minecraft/class_854 net/minecraft/client/render/entity/model/BookModel
+	FIELD field_3704 leftCover Lnet/minecraft/class_900;
+	FIELD field_3705 rightCover Lnet/minecraft/class_900;
+	FIELD field_3706 leftPage Lnet/minecraft/class_900;
+	FIELD field_3707 rightPage Lnet/minecraft/class_900;
+	FIELD field_3708 leftFlippîngPage Lnet/minecraft/class_900;
+	FIELD field_3709 rightFlippingPage Lnet/minecraft/class_900;
+	FIELD field_3710 spine Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/ChickenEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ChickenEntityModel.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_857 net/minecraft/client/render/entity/model/ChickenEntityModel
+	FIELD field_3714 head Lnet/minecraft/class_900;
+	FIELD field_3715 body Lnet/minecraft/class_900;
+	FIELD field_3716 rightLeg Lnet/minecraft/class_900;
+	FIELD field_3717 leftLeg Lnet/minecraft/class_900;
+	FIELD field_3718 rightWing Lnet/minecraft/class_900;
+	FIELD field_3719 leftWing Lnet/minecraft/class_900;
+	FIELD field_3720 beak Lnet/minecraft/class_900;
+	FIELD field_3721 waddle Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/CreeperEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/CreeperEntityModel.mapping
@@ -1,1 +1,12 @@
 CLASS net/minecraft/class_859 net/minecraft/client/render/entity/model/CreeperEntityModel
+	FIELD field_3722 head Lnet/minecraft/class_900;
+	FIELD field_3723 largeHead Lnet/minecraft/class_900;
+		COMMENT Has the shape of the head, but it is .5 larger in size than a normal head. It has texture coordinates pointing to an empty place in the texture atlas.
+		COMMENT This field is initialised but never rendered.
+	FIELD field_3724 body Lnet/minecraft/class_900;
+	FIELD field_3725 rightBackLeg Lnet/minecraft/class_900;
+	FIELD field_3726 leftBackleg Lnet/minecraft/class_900;
+	FIELD field_3727 rightFrontLeg Lnet/minecraft/class_900;
+	FIELD field_3728 leftFrontLeg Lnet/minecraft/class_900;
+	METHOD <init> (F)V
+		ARG 1 reduction

--- a/mappings/net/minecraft/client/render/entity/model/EnderCrystalEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EnderCrystalEntityModel.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_898 net/minecraft/client/render/entity/model/EnderCrystalEntityModel
+	FIELD field_3918 cube Lnet/minecraft/class_900;
+	FIELD field_3919 glass Lnet/minecraft/class_900;
+	FIELD field_3920 base Lnet/minecraft/class_900;
+	METHOD <init> (FZ)V
+		ARG 2 hasBase

--- a/mappings/net/minecraft/client/render/entity/model/EnderDragonEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EnderDragonEntityModel.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_897 net/minecraft/client/render/entity/model/EnderDragonModel
+CLASS net/minecraft/class_897 net/minecraft/client/render/entity/model/EnderDragonEntityModel
 	FIELD field_3905 head Lnet/minecraft/class_900;
 	FIELD field_3906 neck Lnet/minecraft/class_900;
 	FIELD field_3907 jaw Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/EnderDragonModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EnderDragonModel.mapping
@@ -1,1 +1,16 @@
 CLASS net/minecraft/class_897 net/minecraft/client/render/entity/model/EnderDragonModel
+	FIELD field_3905 head Lnet/minecraft/class_900;
+	FIELD field_3906 neck Lnet/minecraft/class_900;
+	FIELD field_3907 jaw Lnet/minecraft/class_900;
+	FIELD field_3908 body Lnet/minecraft/class_900;
+	FIELD field_3909 rearLeg Lnet/minecraft/class_900;
+	FIELD field_3910 frontLeg Lnet/minecraft/class_900;
+	FIELD field_3911 rearLegTip Lnet/minecraft/class_900;
+	FIELD field_3912 frontLegTip Lnet/minecraft/class_900;
+	FIELD field_3913 rearFoot Lnet/minecraft/class_900;
+	FIELD field_3914 frontFoot Lnet/minecraft/class_900;
+	FIELD field_3915 wing Lnet/minecraft/class_900;
+	FIELD field_3916 wingTip Lnet/minecraft/class_900;
+	FIELD field_3917 tickDelta F
+	METHOD method_3093 tickRotation (D)F
+		ARG 1 rotation

--- a/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/EntityModel.mapping
@@ -30,7 +30,7 @@ CLASS net/minecraft/class_871 net/minecraft/client/render/entity/model/EntityMod
 		ARG 5 yaw
 		ARG 6 pitch
 		ARG 7 scale
-	METHOD method_3059 renderHandSwing (Lnet/minecraft/class_1752;FFF)V
+	METHOD method_3059 renderMobAnimation (Lnet/minecraft/class_1752;FFF)V
 		ARG 1 entity
 		ARG 2 handSwing
 		ARG 3 handSwingAmount

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityModel.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_862 net/minecraft/client/render/entity/model/GhastEntityModel
+	FIELD field_3735 body Lnet/minecraft/class_900;
+	FIELD field_3736 tentacles [Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/GhastEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/GhastEntityRenderer.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_862 net/minecraft/client/render/entity/model/GhastEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
@@ -54,12 +54,12 @@ CLASS net/minecraft/class_864 net/minecraft/client/render/entity/model/HorseEnti
 	FIELD field_3778 backRightCannon Lnet/minecraft/class_900;
 		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">cannon</a> is the lower part of a horse's leg.
 	FIELD field_3779 backRightHoof Lnet/minecraft/class_900;
-	METHOD method_3048 (FFF)F
+	METHOD method_3048 tickRotation (FFF)F
 		ARG 1 prevBodyYaw
 		ARG 2 bodyYaw
 		ARG 3 tickdelta
-	METHOD method_3049 setModelPos (Lnet/minecraft/class_900;FFF)V
+	METHOD method_3049 setModelRotation (Lnet/minecraft/class_900;FFF)V
 		ARG 1 model
-		ARG 2 x
-		ARG 3 y
-		ARG 4 z
+		ARG 2 rotationX
+		ARG 3 rotationY
+		ARG 4 rotationZ

--- a/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
@@ -1,4 +1,65 @@
 CLASS net/minecraft/class_864 net/minecraft/client/render/entity/model/HorseEntityModel
+	FIELD field_3741 leftForearm Lnet/minecraft/class_900;
+	FIELD field_3742 frontLeftCannon Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">cannon</a> is the lower part of a horse's leg.
+	FIELD field_3743 frontLeftHoof Lnet/minecraft/class_900;
+	FIELD field_3744 rightForearm Lnet/minecraft/class_900;
+	FIELD field_3745 frontRightCannon Lnet/minecraft/class_900;
+	FIELD field_3746 frontRightHoof Lnet/minecraft/class_900;
+	FIELD field_3747 leftDonkeyChest Lnet/minecraft/class_900;
+	FIELD field_3748 rightDonkeyChest Lnet/minecraft/class_900;
+	FIELD field_3749 saddleSeat Lnet/minecraft/class_900;
+	FIELD field_3750 gullet Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle">gullet</a> is the front part of a horse's saddle.
+	FIELD field_3751 cantle Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle">cantle</a> is the back part of a horse's saddle.
+	FIELD field_3752 leftFender Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle#Parts">fender</a> is the leather strap connecting the saddle to the stirrup..
+	FIELD field_3753 leftStirrup Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle#Parts">stirrup</a> is the metal part in which a horse's rider puts their foot.
+	FIELD field_3754 rightFender Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle#Parts">fender</a> is the leather strap connecting the saddle to the stirrup..
+	FIELD field_3755 rightStirrup Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Saddle#Parts">stirrup</a> is the metal part in which a horse's rider puts their foot.
+	FIELD field_3756 leftSnaffleBit Lnet/minecraft/class_900;
+		COMMENT The <a href=https://en.wikipedia.org/wiki/Snaffle_bit>snaffle bit</a> are the metal rings to chich one connects the reigns.
+	FIELD field_3757 rightSnaffleBit Lnet/minecraft/class_900;
+		COMMENT The <a href=https://en.wikipedia.org/wiki/Snaffle_bit>snaffle bit</a> are the metal rings to chich one connects the reigns
+	FIELD field_3758 leftReigh Lnet/minecraft/class_900;
+	FIELD field_3759 rightReign Lnet/minecraft/class_900;
 	FIELD field_3760 head Lnet/minecraft/class_900;
-	FIELD field_3761 topMouth Lnet/minecraft/class_900;
-	FIELD field_3762 bottomMouth Lnet/minecraft/class_900;
+	FIELD field_3761 topJaw Lnet/minecraft/class_900;
+	FIELD field_3762 bottomJaw Lnet/minecraft/class_900;
+	FIELD field_3763 donkeyLeftEar Lnet/minecraft/class_900;
+	FIELD field_3764 donkeyRightEar Lnet/minecraft/class_900;
+	FIELD field_3765 muleEarLeft Lnet/minecraft/class_900;
+	FIELD field_3766 muleEarRight Lnet/minecraft/class_900;
+	FIELD field_3767 neck Lnet/minecraft/class_900;
+	FIELD field_3768 halster Lnet/minecraft/class_900;
+		COMMENT  <a href="https://en.wikipedia.org/wiki/Halter">Halters</a>  are the ropes around the horse's face.
+	FIELD field_3769 mane Lnet/minecraft/class_900;
+	FIELD field_3770 mainBody Lnet/minecraft/class_900;
+	FIELD field_3771 dock Lnet/minecraft/class_900;
+		COMMENT A <a href="https://en.wikipedia.org/wiki/Tail_(horse)">dock</a> is the area where the tail connects to the body of a horse.
+	FIELD field_3772 tail Lnet/minecraft/class_900;
+	FIELD field_3773 skirt Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Tail_(horse)">skirt</a> are the long hairs extending down at the tail.
+	FIELD field_3774 leftThigh Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">thigh</a> is the upper part of a horse's back leg.
+	FIELD field_3775 backLeftCannon Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">cannon</a> is the lower part of a horse's leg.
+	FIELD field_3776 backLeftHoof Lnet/minecraft/class_900;
+	FIELD field_3777 rightThigh Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">thigh</a> is the upper part of a horse's back leg.
+	FIELD field_3778 backRightCannon Lnet/minecraft/class_900;
+		COMMENT The <a href="https://en.wikipedia.org/wiki/Equine_anatomy#External_anatomy">cannon</a> is the lower part of a horse's leg.
+	FIELD field_3779 backRightHoof Lnet/minecraft/class_900;
+	METHOD method_3048 (FFF)F
+		ARG 1 prevBodyYaw
+		ARG 2 bodyYaw
+		ARG 3 tickdelta
+	METHOD method_3049 setModelPos (Lnet/minecraft/class_900;FFF)V
+		ARG 1 model
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HorseEntityModel.mapping
@@ -25,7 +25,7 @@ CLASS net/minecraft/class_864 net/minecraft/client/render/entity/model/HorseEnti
 		COMMENT The <a href=https://en.wikipedia.org/wiki/Snaffle_bit>snaffle bit</a> are the metal rings to chich one connects the reigns.
 	FIELD field_3757 rightSnaffleBit Lnet/minecraft/class_900;
 		COMMENT The <a href=https://en.wikipedia.org/wiki/Snaffle_bit>snaffle bit</a> are the metal rings to chich one connects the reigns
-	FIELD field_3758 leftReigh Lnet/minecraft/class_900;
+	FIELD field_3758 leftReign Lnet/minecraft/class_900;
 	FIELD field_3759 rightReign Lnet/minecraft/class_900;
 	FIELD field_3760 head Lnet/minecraft/class_900;
 	FIELD field_3761 topJaw Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/HumanoidEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/HumanoidEntityModel.mapping
@@ -1,14 +1,13 @@
-CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/BipedEntityModel
-	COMMENT This class is used for some, but not all bipedal mobs. Entities that use this class or extend from it are:
+CLASS net/minecraft/class_866 net/minecraft/client/render/entity/model/HumanoidEntityModel
+	COMMENT This class is used for some, but not all humanoid mobs. Entities that use this class or extend from it are:
 	COMMENT <ul>
 	COMMENT <li>Zombie/Zombie Villager</li>
 	COMMENT <li>Player</li>
 	COMMENT <li>Skelleto</li>
 	COMMENT </ul>
 	COMMENT
-	COMMENT Mobs that don't use this class but are bipedal:
+	COMMENT Mobs that don't use this class but are humanoid:
 	COMMENT <ul>
-	COMMENT <li>Chicken</li>
 	COMMENT <li>Witch</li>
 	COMMENT <li>Villager</li>
 	COMMENT <li>Iron Golem</li>

--- a/mappings/net/minecraft/client/render/entity/model/IronGolemEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/IronGolemEntityModel.mapping
@@ -1,1 +1,15 @@
 CLASS net/minecraft/class_890 net/minecraft/client/render/entity/model/IronGolemEntityModel
+	FIELD field_3880 head Lnet/minecraft/class_900;
+	FIELD field_3881 body Lnet/minecraft/class_900;
+	FIELD field_3882 rightArm Lnet/minecraft/class_900;
+	FIELD field_3883 leftArm Lnet/minecraft/class_900;
+	FIELD field_3884 rightLeg Lnet/minecraft/class_900;
+	FIELD field_3885 leftLeg Lnet/minecraft/class_900;
+	METHOD <init> (F)V
+		ARG 1 reduction
+	METHOD <init> (FF)V
+		ARG 1 reduction
+		ARG 2 pivotPoint
+	METHOD method_3092 getRotation (FF)F
+		ARG 1 rotation
+		ARG 2 tickDelta

--- a/mappings/net/minecraft/client/render/entity/model/LeashEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LeashEntityModel.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_869 net/minecraft/client/render/entity/model/LeashEntityModel
+	FIELD field_3794 leash Lnet/minecraft/class_900;
+	METHOD <init> (IIII)V
+		ARG 1 textureOffsetU
+		ARG 2 textureOffsetV
+		ARG 3 textureWidth
+		ARG 4 textureHeight

--- a/mappings/net/minecraft/client/render/entity/model/LightningBoltEntityRenderer.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/LightningBoltEntityRenderer.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_2365 net/minecraft/client/render/entity/model/LightningBoltEntityRenderer

--- a/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MagmaCubeEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_868 net/minecraft/client/render/entity/model/MagmaCubeEntityModel
+	FIELD field_3792 slices [Lnet/minecraft/class_900;
+	FIELD field_3793 body Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/MinecartEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_870 net/minecraft/client/render/entity/model/MinecartEntityModel
+	FIELD field_3795 parts [Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/OcelotEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/OcelotEntityModel.mapping
@@ -1,1 +1,16 @@
 CLASS net/minecraft/class_872 net/minecraft/client/render/entity/model/OcelotEntityModel
+	FIELD field_3803 backLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3804 backRightLeg Lnet/minecraft/class_900;
+	FIELD field_3805 frontLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3806 frontrightLeg Lnet/minecraft/class_900;
+	FIELD field_3807 upperTail Lnet/minecraft/class_900;
+	FIELD field_3808 lowerTail Lnet/minecraft/class_900;
+	FIELD field_3809 head Lnet/minecraft/class_900;
+	FIELD field_3810 body Lnet/minecraft/class_900;
+	FIELD field_3811 movementType I
+		COMMENT <ul>
+		COMMENT <li>0: sneaking</li>
+		COMMENT <li>1: stationary</li>
+		COMMENT <li>2: sprinting</li>
+		COMMENT <li>3: sitting</li>
+		COMMENT </ul>

--- a/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
@@ -1,4 +1,16 @@
 CLASS net/minecraft/class_876 net/minecraft/client/render/entity/model/QuadrupedEntityModel
+	COMMENT This class is used for some, but not all quadrupedal mobs. Entities that use this class or extend from it are:
+	COMMENT <ul>
+	COMMENT <li>Cows</li>
+	COMMENT <li>Pigs</li>
+	COMMENT <li>Sheep</li>
+	COMMENT </ul>
+	COMMENT
+	COMMENT There are some more complex mobs that don't use this class but are quadrupedal:
+	COMMENT <ul>
+	COMMENT <li>Ocelots</li>
+	COMMENT <li>Wolves</li>
+	COMMENT </ul>
 	FIELD field_3823 head Lnet/minecraft/class_900;
 	FIELD field_3824 body Lnet/minecraft/class_900;
 	FIELD field_3825 backRightLeg Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_876 net/minecraft/client/render/entity/model/QuadruPedEntityModel
+CLASS net/minecraft/class_876 net/minecraft/client/render/entity/model/QuadrupedEntityModel
 	FIELD field_3823 head Lnet/minecraft/class_900;
 	FIELD field_3824 body Lnet/minecraft/class_900;
 	FIELD field_3825 backRightLeg Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/QuadruPedEntityModel.mapping
@@ -1,1 +1,12 @@
 CLASS net/minecraft/class_876 net/minecraft/client/render/entity/model/QuadruPedEntityModel
+	FIELD field_3823 head Lnet/minecraft/class_900;
+	FIELD field_3824 body Lnet/minecraft/class_900;
+	FIELD field_3825 backRightLeg Lnet/minecraft/class_900;
+	FIELD field_3826 backLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3827 frontRightLeg Lnet/minecraft/class_900;
+	FIELD field_3828 frontLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3829 babyHeadHeightOffset F
+	FIELD field_3830 babyHeadOffset F
+	METHOD <init> (IF)V
+		ARG 1 pivotPoint
+		ARG 2 reduction

--- a/mappings/net/minecraft/client/render/entity/model/SheepEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SheepEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_879 net/minecraft/client/render/entity/model/SheepEntityModel
+	FIELD field_3846 tickdelta F

--- a/mappings/net/minecraft/client/render/entity/model/SheepWoolEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SheepWoolEntityModel.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_878 net/minecraft/client/render/entity/model/SheepWoolEntityModel
+	FIELD field_3845 headAngle F

--- a/mappings/net/minecraft/client/render/entity/model/SignBlockEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SignBlockEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_880 net/minecraft/client/render/entity/model/SignBlockEntityModel
+	FIELD field_3847 board Lnet/minecraft/class_900;
+	FIELD field_3848 pole Lnet/minecraft/class_900;
+	METHOD method_3067 render ()V

--- a/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SilverfishEntityModel.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_881 net/minecraft/client/render/entity/model/SilverfishEntityModel
+	FIELD field_3849 body [Lnet/minecraft/class_900;
+	FIELD field_3850 scales [Lnet/minecraft/class_900;
+	FIELD field_3851 radii [F
+	FIELD field_3852 SEGMENT_LOCATIONS [[I
+	FIELD field_3853 SEGMENT_SIZES [[I

--- a/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SlimeEntityModel.mapping
@@ -1,1 +1,7 @@
 CLASS net/minecraft/class_885 net/minecraft/client/render/entity/model/SlimeEntityModel
+	FIELD field_3855 body Lnet/minecraft/class_900;
+	FIELD field_3856 rightEye Lnet/minecraft/class_900;
+	FIELD field_3857 leftEye Lnet/minecraft/class_900;
+	FIELD field_3858 mouth Lnet/minecraft/class_900;
+	METHOD <init> (I)V
+		ARG 1 size

--- a/mappings/net/minecraft/client/render/entity/model/SnowGolemEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SnowGolemEntityModel.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_886 net/minecraft/client/render/entity/model/SnowmanEntityModel
+CLASS net/minecraft/class_886 net/minecraft/client/render/entity/model/SnowGolemEntityModel
 	FIELD field_3859 top Lnet/minecraft/class_900;
 	FIELD field_3860 bottom Lnet/minecraft/class_900;
 	FIELD field_3861 head Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/SnowmanEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SnowmanEntityModel.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_886 net/minecraft/client/render/entity/model/SnowmanEntityModel
+	FIELD field_3859 top Lnet/minecraft/class_900;
+	FIELD field_3860 bottom Lnet/minecraft/class_900;
+	FIELD field_3861 head Lnet/minecraft/class_900;
+	FIELD field_3862 rightArm Lnet/minecraft/class_900;
+	FIELD field_3863 leftArm Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
@@ -1,1 +1,12 @@
 CLASS net/minecraft/class_887 net/minecraft/client/render/entity/model/SpiderEntityModel
+	FIELD field_3864 head Lnet/minecraft/class_900;
+	FIELD field_3865 neck Lnet/minecraft/class_900;
+	FIELD field_3866 body Lnet/minecraft/class_900;
+	FIELD field_3867 backRightLeg Lnet/minecraft/class_900;
+	FIELD field_3868 backLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3869 backMiddleRightLeg Lnet/minecraft/class_900;
+	FIELD field_3870 backMiddleLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3871 frontMiddlerightLeg Lnet/minecraft/class_900;
+	FIELD field_3872 frontMiddleLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3873 frontRightLeg Lnet/minecraft/class_900;
+	FIELD field_3874 frontLeftLeg Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SpiderEntityModel.mapping
@@ -6,7 +6,7 @@ CLASS net/minecraft/class_887 net/minecraft/client/render/entity/model/SpiderEnt
 	FIELD field_3868 backLeftLeg Lnet/minecraft/class_900;
 	FIELD field_3869 backMiddleRightLeg Lnet/minecraft/class_900;
 	FIELD field_3870 backMiddleLeftLeg Lnet/minecraft/class_900;
-	FIELD field_3871 frontMiddlerightLeg Lnet/minecraft/class_900;
+	FIELD field_3871 frontMiddleRightLeg Lnet/minecraft/class_900;
 	FIELD field_3872 frontMiddleLeftLeg Lnet/minecraft/class_900;
 	FIELD field_3873 frontRightLeg Lnet/minecraft/class_900;
 	FIELD field_3874 frontLeftLeg Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/SquidEntityModel.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_888 net/minecraft/client/render/entity/model/SquidEntityModel
+	FIELD field_3875 body Lnet/minecraft/class_900;
+	FIELD field_3876 legs [Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/VillagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/VillagerEntityModel.mapping
@@ -1,1 +1,14 @@
 CLASS net/minecraft/class_891 net/minecraft/client/render/entity/model/VillagerEntityModel
+	FIELD field_3886 head Lnet/minecraft/class_900;
+	FIELD field_3887 body Lnet/minecraft/class_900;
+	FIELD field_3888 arms Lnet/minecraft/class_900;
+	FIELD field_3889 rightLeg Lnet/minecraft/class_900;
+	FIELD field_3890 leftLeg Lnet/minecraft/class_900;
+	FIELD field_3891 nose Lnet/minecraft/class_900;
+	METHOD <init> (F)V
+		ARG 1 reduction
+	METHOD <init> (FFII)V
+		ARG 1 reduction
+		ARG 2 pivotPoint
+		ARG 3 width
+		ARG 4 height

--- a/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitchEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_893 net/minecraft/client/render/entity/model/WitchEntityModel
+	FIELD field_3892 heldItemId Z
+	FIELD field_3893 mole Lnet/minecraft/class_900;
+	FIELD field_3894 hat Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WitherEntityModel.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_894 net/minecraft/client/render/entity/model/WitherEntityModel
+	FIELD field_3895 body [Lnet/minecraft/class_900;
+	FIELD field_3896 skulls [Lnet/minecraft/class_900;
+	METHOD method_9275 maxHands ()I

--- a/mappings/net/minecraft/client/render/entity/model/WolfEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/WolfEntityModel.mapping
@@ -1,1 +1,9 @@
 CLASS net/minecraft/class_895 net/minecraft/client/render/entity/model/WolfEntityModel
+	FIELD field_3897 head Lnet/minecraft/class_900;
+	FIELD field_3898 body Lnet/minecraft/class_900;
+	FIELD field_3899 backRightLeg Lnet/minecraft/class_900;
+	FIELD field_3900 backLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3901 frontRightLeg Lnet/minecraft/class_900;
+	FIELD field_3902 frontLeftLeg Lnet/minecraft/class_900;
+	FIELD field_3903 tail Lnet/minecraft/class_900;
+	FIELD field_3904 neck Lnet/minecraft/class_900;

--- a/mappings/net/minecraft/client/render/entity/model/ZombieEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieEntityModel.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_896 net/minecraft/client/render/entity/model/ZombieEntityModel
+	METHOD <init> (FZ)V
+		ARG 1 reduction
+		ARG 2 pivot

--- a/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
+++ b/mappings/net/minecraft/client/render/entity/model/ZombieVillagerEntityModel.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_892 net/minecraft/client/render/entity/model/ZombieVillagerEntityModel
+	METHOD <init> (FFZ)V
+		ARG 1 reduction
+		ARG 2 rotationAngle
+		ARG 3 texture
+	METHOD method_9274 maxHands ()I

--- a/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
+++ b/mappings/net/minecraft/client/util/ScreenshotUtils.mapping
@@ -2,6 +2,7 @@ CLASS net/minecraft/class_674 net/minecraft/client/util/ScreenshotUtils
 	FIELD field_2792 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_2793 DATE_FORMAT Ljava/text/DateFormat;
 	FIELD field_2794 intBuffer Ljava/nio/IntBuffer;
+	FIELD field_2795 buffer [I
 	METHOD method_2370 getScreenshotFile (Ljava/io/File;)Ljava/io/File;
 		ARG 0 screenshotsDirectory
 	METHOD method_2371 saveScreenshot (Ljava/io/File;IILnet/minecraft/class_1040;)Lnet/minecraft/class_1444;

--- a/mappings/net/minecraft/entity/living/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/living/player/PlayerEntity.mapping
@@ -7,6 +7,7 @@ CLASS net/minecraft/class_2674 net/minecraft/entity/living/player/PlayerEntity
 	FIELD field_11717 xpTotal I
 	FIELD field_11718 xp F
 	FIELD field_11719 sleepTimer I
+	FIELD field_11720 speed F
 	FIELD field_11721 flyingSpeed F
 	FIELD field_11722 fishingBobber Lnet/minecraft/class_1887;
 	FIELD field_11723 inventory Lnet/minecraft/class_1962;
@@ -128,6 +129,7 @@ CLASS net/minecraft/class_2674 net/minecraft/entity/living/player/PlayerEntity
 	METHOD method_10885 getHungerManager ()Lnet/minecraft/class_1982;
 	METHOD method_10886 needsHealing ()Z
 	METHOD method_10887 getEnderChestInventory ()Lnet/minecraft/class_2007;
+	METHOD method_10888 hidesCape ()Z
 	METHOD method_10889 getScoreboard ()Lnet/minecraft/class_653;
 	METHOD method_10890 getItemInHand ()Lnet/minecraft/class_2056;
 	METHOD method_10891 getItemUseTimer ()I

--- a/mappings/net/minecraft/util/NetworkUtils.mapping
+++ b/mappings/net/minecraft/util/NetworkUtils.mapping
@@ -10,13 +10,14 @@ CLASS net/minecraft/class_1694 net/minecraft/util/NetworkUtils
 		ARG 5 progressListener
 		ARG 6 proxy
 	METHOD method_6573 getLocalPort ()I
-	METHOD method_6576 (Ljava/net/URL;Ljava/lang/String;Z)Ljava/lang/String;
+	METHOD method_6576 getLangFile (Ljava/net/URL;Ljava/lang/String;Z)Ljava/lang/String;
 		ARG 0 url
 		ARG 1 contentLength
 		ARG 2 quietly
-	METHOD method_6577 (Ljava/net/URL;Ljava/util/Map;Z)Ljava/lang/String;
+	METHOD method_6577 getLangFile (Ljava/net/URL;Ljava/util/Map;Z)Ljava/lang/String;
 		ARG 0 url
 		ARG 1 hasmap
-	METHOD method_6578 (Ljava/util/Map;)Ljava/lang/String;
+		ARG 2 quietly
+	METHOD method_6578 getString (Ljava/util/Map;)Ljava/lang/String;
 		ARG 0 hashMap
 	METHOD method_6579 getLogger ()Lorg/apache/logging/log4j/Logger;

--- a/mappings/net/minecraft/world/carver/RavineCarver.mapping
+++ b/mappings/net/minecraft/world/carver/RavineCarver.mapping
@@ -1,6 +1,13 @@
 CLASS net/minecraft/class_415 net/minecraft/world/carver/RavineCarver
+	FIELD field_1646 buffer [F
 	METHOD method_1492 (JII[Lnet/minecraft/class_160;DDDFFFIID)V
+		ARG 1 seed
+		ARG 3 x
+		ARG 4 z
 		ARG 5 blocks
-		ARG 6 x
-		ARG 8 y
-		ARG 10 z
+		ARG 6 xRandom
+		ARG 8 yRandom
+		ARG 10 zRandom
+		ARG 12 randomMultiplier
+		ARG 13 anglePos
+		ARG 14 angleMumtiplier

--- a/mappings/net/minecraft/world/dimension/Dimension.mapping
+++ b/mappings/net/minecraft/world/dimension/Dimension.mapping
@@ -39,5 +39,6 @@ CLASS net/minecraft/class_411 net/minecraft/world/dimension/Dimension
 	METHOD method_1480 hasGround ()Z
 	METHOD method_1481 getForcedSpawnPoint ()Lnet/minecraft/class_2614;
 	METHOD method_1482 getMinSpawnY ()I
+	METHOD method_1483 getFogSioze ()D
 	METHOD method_1484 getDimensionName ()Ljava/lang/String;
 	METHOD method_1487 doesWaterVaporize ()Z

--- a/mappings/net/minecraft/world/dimension/Dimension.mapping
+++ b/mappings/net/minecraft/world/dimension/Dimension.mapping
@@ -39,6 +39,6 @@ CLASS net/minecraft/class_411 net/minecraft/world/dimension/Dimension
 	METHOD method_1480 hasGround ()Z
 	METHOD method_1481 getForcedSpawnPoint ()Lnet/minecraft/class_2614;
 	METHOD method_1482 getMinSpawnY ()I
-	METHOD method_1483 getFogSioze ()D
+	METHOD method_1483 getFogSize ()D
 	METHOD method_1484 getDimensionName ()Ljava/lang/String;
 	METHOD method_1487 doesWaterVaporize ()Z

--- a/mappings/net/minecraft/world/gen/FlatWorldHelper.mapping
+++ b/mappings/net/minecraft/world/gen/FlatWorldHelper.mapping
@@ -1,7 +1,15 @@
 CLASS net/minecraft/class_473 net/minecraft/world/gen/FlatWorldHelper
 	FIELD field_1970 biomeId I
+	FIELD field_9656 layers Ljava/util/List;
+	FIELD field_9657 featureMap Ljava/util/Map;
 	METHOD method_1563 getBiomeId ()I
 	METHOD method_1564 setBiomeId (I)V
 		ARG 1 biomeId
+	METHOD method_1567 createFlatWorld (Ljava/lang/String;)Lnet/minecraft/class_473;
+		ARG 0 preset
+	METHOD method_1568 getFeatureMap ()Ljava/util/Map;
 	METHOD method_1569 getLayers ()Ljava/util/List;
+	METHOD method_1570 processLayers ()V
 	METHOD method_1571 createDefault ()Lnet/minecraft/class_473;
+	METHOD method_8982 getLayers (Ljava/lang/String;)Ljava/util/List;
+		ARG 0 preset

--- a/mappings/net/minecraft/world/gen/FlatWorldHelper.mapping
+++ b/mappings/net/minecraft/world/gen/FlatWorldHelper.mapping
@@ -5,6 +5,9 @@ CLASS net/minecraft/class_473 net/minecraft/world/gen/FlatWorldHelper
 	METHOD method_1563 getBiomeId ()I
 	METHOD method_1564 setBiomeId (I)V
 		ARG 1 biomeId
+	METHOD method_1566 parsePreset (Ljava/lang/String;I)Lnet/minecraft/class_475;
+		ARG 0 text
+		ARG 1 id
 	METHOD method_1567 createFlatWorld (Ljava/lang/String;)Lnet/minecraft/class_473;
 		ARG 0 preset
 	METHOD method_1568 getFeatureMap ()Ljava/util/Map;

--- a/mappings/net/minecraft/world/gen/NetherCaveGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/NetherCaveGenerator.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_425 net/minecraft/world/gen/NetherCaveGenerator
-	METHOD method_1511 (JII[Lnet/minecraft/class_160;DDD)V
+	METHOD method_1511 generatePiece (JII[Lnet/minecraft/class_160;DDD)V
 		ARG 1 randomSeed
 		ARG 3 x
 		ARG 4 z
@@ -7,7 +7,7 @@ CLASS net/minecraft/class_425 net/minecraft/world/gen/NetherCaveGenerator
 		ARG 6 xRandom
 		ARG 8 yRandom
 		ARG 10 zRandom
-	METHOD method_1512 (JII[Lnet/minecraft/class_160;DDDFFFIID)V
+	METHOD method_1512 generateCorridor (JII[Lnet/minecraft/class_160;DDDFFFIID)V
 		ARG 1 randomSeed
 		ARG 3 x
 		ARG 4 z
@@ -15,4 +15,6 @@ CLASS net/minecraft/class_425 net/minecraft/world/gen/NetherCaveGenerator
 		ARG 6 xRandom
 		ARG 8 yRandom
 		ARG 10 zRandom
-		ARG 13 randomAngle
+		ARG 12 randomMultiplier
+		ARG 13 anglePos
+		ARG 14 angleMumltiplier

--- a/mappings/net/minecraft/world/gen/NetherCaveGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/NetherCaveGenerator.mapping
@@ -17,4 +17,4 @@ CLASS net/minecraft/class_425 net/minecraft/world/gen/NetherCaveGenerator
 		ARG 10 zRandom
 		ARG 12 randomMultiplier
 		ARG 13 anglePos
-		ARG 14 angleMumltiplier
+		ARG 14 angleMultiplier

--- a/mappings/net/minecraft/world/gen/feature/DiskFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/DiskFeature.mapping
@@ -1,1 +1,6 @@
 CLASS net/minecraft/class_463 net/minecraft/world/gen/feature/DiskFeature
+	FIELD field_1951 baseBlock Lnet/minecraft/class_160;
+	FIELD field_1952 size I
+	METHOD <init> (Lnet/minecraft/class_160;I)V
+		ARG 1 baseBlock
+		ARG 2 size

--- a/mappings/net/minecraft/world/gen/feature/LakesFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/LakesFeature.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_451 net/minecraft/world/gen/feature/LakesFeature
+	FIELD field_1932 baseBlock Lnet/minecraft/class_160;
+	METHOD <init> (Lnet/minecraft/class_160;)V
+		ARG 1 baseBlock

--- a/mappings/net/minecraft/world/gen/layer/FlatWorldLayer.mapping
+++ b/mappings/net/minecraft/world/gen/layer/FlatWorldLayer.mapping
@@ -1,2 +1,18 @@
 CLASS net/minecraft/class_475 net/minecraft/world/gen/layer/FlatWorldLayer
+	FIELD field_1974 layerId I
+	FIELD field_9658 block Lnet/minecraft/class_160;
+	FIELD field_9659 layerCount I
+	FIELD field_9660 layerMetadata I
+	METHOD <init> (ILnet/minecraft/class_160;)V
+		ARG 1 layerCount
+		ARG 2 block
+	METHOD <init> (ILnet/minecraft/class_160;I)V
+		ARG 1 layerCount
+		ARG 2 block
+		ARG 3 metadata
+	METHOD method_1572 getLayerCount ()I
+	METHOD method_1573 getLayerId (I)V
+		ARG 1 layerId
 	METHOD method_1574 getBlockState ()Lnet/minecraft/class_160;
+	METHOD method_1575 setLayerId ()I
+	METHOD method_8983 getLayerMetadata ()I


### PR DESCRIPTION
Mapped all model classes in this package.
Renamed some classes that were not following the naming convention with `EntityModel` at the end.
Moved some mispackaged classes.
Removed some mappings of variable/field names as `unused`.
Added some javadocs.