### PR TITLE
Renamed `fileSize` to `bytesWritten` in `RegionFile`

### DIFF
--- a/mappings/net/minecraft/server/world/chunk/RegionFile.mapping
+++ b/mappings/net/minecraft/server/world/chunk/RegionFile.mapping
@@ -9,9 +9,10 @@ CLASS net/minecraft/class_407 net/minecraft/server/world/chunk/RegionFile
 	FIELD field_1622 saveTimes [I
 		COMMENT Contains the times for the latest modification to each chunk. This array
 		COMMENT is also written to the region file starting at byte 4096.
-	FIELD field_1624 fileSize I
-		COMMENT The total number of bytes stored in the region file. Note that this is always
-		COMMENT a multiple of 4096 (the size of a single block).
+	FIELD field_1624 bytesWritten I
+		COMMENT The total number of bytes written to the region file, since this {@code RegionFile}
+		COMMENT object was instantiated. Note that this is always a multiple of 4096 (the size
+		COMMENT of a single block).
 	FIELD field_1625 lastModifiedTime J
 	FIELD field_9606 blockEmptyFlags Ljava/util/ArrayList;
 		COMMENT A list containing flags for each of the blocks in the file indicating whether


### PR DESCRIPTION
The field named `fileSize` is actually the number of bytes that have been written to the region file since the RegionFile object was instantiated. Fixed in this PR.