### PR TITLE
Misc mappings (DRAFT PR)

### DIFF
--- a/mappings/net/minecraft/client/entity/living/player/ClientBehaviorPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/entity/living/player/ClientBehaviorPlayerEntity.mapping
@@ -1,5 +1,7 @@
 CLASS net/minecraft/class_2335 net/minecraft/client/entity/living/player/ClientBehaviorPlayerEntity
 	FIELD field_10283 horseJumpTimer I
+	FIELD field_10285 netherPortalDuration F
+	FIELD field_10286 oldNetherPortalDuration F
 	FIELD field_10287 horseJumpSize F
 	FIELD field_10288 Lnet/minecraft/class_1708;
 		COMMENT unused in 1.7.2
@@ -9,6 +11,7 @@ CLASS net/minecraft/class_2335 net/minecraft/client/entity/living/player/ClientB
 		COMMENT unused in 1.7.2
 	FIELD field_10291 input Lnet/minecraft/class_994;
 	FIELD field_10292 client Lnet/minecraft/class_669;
+	FIELD field_10293 doubleTapSprintTimer I
 	FIELD field_10294 sprintingCooldown I
 	METHOD <init> (Lnet/minecraft/class_669;Lnet/minecraft/class_99;Lnet/minecraft/class_677;I)V
 		ARG 1 client

--- a/mappings/net/minecraft/client/entity/living/player/ClientPlayerEntity.mapping
+++ b/mappings/net/minecraft/client/entity/living/player/ClientPlayerEntity.mapping
@@ -1,6 +1,18 @@
 CLASS net/minecraft/class_2322 net/minecraft/client/entity/living/player/ClientPlayerEntity
 	FIELD field_10231 networkHandler Lnet/minecraft/class_2314;
 	FIELD field_10232 statHandler Lnet/minecraft/class_1688;
+	FIELD field_10233 lastX D
+	FIELD field_10234 lastY D
+	FIELD field_10235 D
+		COMMENT Not used in 1.7.2 even tho it is assigned a value
+	FIELD field_10236 lastZ D
+	FIELD field_10237 lastYaw F
+	FIELD field_10238 lastPitch F
+	FIELD field_10239 wasOnGround Z
+	FIELD field_10240 wasSneaking Z
+	FIELD field_10241 wasSprinting Z
+	FIELD field_10242 movementUpdateTimer I
+	FIELD field_10243 healthInitialized Z
 	FIELD field_10244 serverBrand Ljava/lang/String;
 	METHOD <init> (Lnet/minecraft/class_669;Lnet/minecraft/class_99;Lnet/minecraft/class_677;Lnet/minecraft/class_2314;Lnet/minecraft/class_1688;)V
 		ARG 1 client
@@ -8,6 +20,7 @@ CLASS net/minecraft/class_2322 net/minecraft/client/entity/living/player/ClientP
 		ARG 3 session
 		ARG 4 networkHandler
 		ARG 5 statHandler
+	METHOD method_9327 updateMovement ()V
 	METHOD method_9328 sendChatMessage (Ljava/lang/String;)V
 		ARG 1 message
 	METHOD method_9329 closeScreen ()V

--- a/mappings/net/minecraft/client/realms/gui/screen/RealmsTermsScreen.mapping
+++ b/mappings/net/minecraft/client/realms/gui/screen/RealmsTermsScreen.mapping
@@ -1,3 +1,13 @@
 CLASS net/minecraft/class_2723 net/minecraft/client/realms/gui/screen/RealmsTermsScreen
 	FIELD field_12018 LOGGER Lorg/apache/logging/log4j/Logger;
+	FIELD field_12019 parentScreen Lnet/minecraft/class_2292;
+	FIELD field_12020 realmsServer Lnet/minecraft/class_2739;
+	FIELD field_12021 agreeToTermsButton Lnet/minecraft/class_685;
+	FIELD field_12022 hoveringOnLink Z
+	FIELD field_12023 realmsTermsUrl Ljava/lang/String;
+	METHOD <init> (Lnet/minecraft/class_2292;Lnet/minecraft/class_2739;)V
+		ARG 1 parentScreen
+		ARG 2 realmsServer
+	METHOD method_11151 openURL (Ljava/lang/String;)V
+		ARG 1 url
 	METHOD method_11152 agreedToTos ()V


### PR DESCRIPTION
One Mojang obfuscation mapping name has been directly used - `wasSprinting` - Its a fairly trivial name and any different name would have been inconsistent with other mappings in the class