### PR TITLE
Fix a remove in the diff not matching with the dst name.

### DIFF
--- a/mappings/18w05a#18w06a.tinydiff
+++ b/mappings/18w05a#18w06a.tinydiff
@@ -5221,7 +5221,7 @@ c	net/minecraft/unmapped/C_4693257
 		p	1		p_1	
 	m	(Lnet/minecraft/unmapped/C_2454309;)Lnet/minecraft/unmapped/C_0191817;	m_8477191	getTab	
 		p	0		result	
-	m	(Lnet/minecraft/unmapped/C_0191817;)Ljava/util/List;	m_4557531	m_4557531	
+	m	(Lnet/minecraft/unmapped/C_0191817;)Ljava/util/List;	m_4557531	getResultsForGroup	
 		p	1		p_1	
 	m	(Lnet/minecraft/unmapped/C_0191817;)Ljava/util/List;	m_3241409	m_3241409	
 		p	0		key	


### PR DESCRIPTION
Somehow the mappings diff from `18w05a` to `18w06a` removes the method `src = m_4557531` with `dst = m_4557531`, but the actual method in this case has `src = m_4557531` and `dst = getResultsForGroup`. Somehow mappings-utils doesn't hard fail on this error.

From the following lines you can see that the method is added under the name of `getResultsForGroup`, and removed with the name `m_4557531`. The addition of a method with the same names (but different descriptor) indicates that the method was most likely moved or the descriptor changed.
```
mappings/17w47b#17w48a.tinydiff:	m	(Lnet/minecraft/unmapped/C_0191817;)Ljava/util/List;	m_4557531		getResultsForGroup
mappings/18w05a#18w06a.tinydiff:	m	(Lnet/minecraft/unmapped/C_0191817;)Ljava/util/List;	m_4557531	m_4557531
mappings/18w05a#18w06a.tinydiff:	m	(Lnet/minecraft/unmapped/C_4569443;)Ljava/util/List;	m_4557531		getResultsForGroup
```
This is now fixed.