### PR TITLE
0.30 mappings

### DIFF
--- a/mappings/c0.0.11a-launcher#rd-161348-launcher.tinydiff
+++ b/mappings/c0.0.11a-launcher#rd-161348-launcher.tinydiff
@@ -18,15 +18,15 @@ c	net/minecraft/client/Minecraft
 	f	Z	f_5170474	running	
 	f	Ljava/lang/String;	f_8891450	fpsDebugInfo	
 	f	Z	f_0682520	focused	
-	f	Z	f_7579809	f_7579809	
-	f	Lorg/lwjgl/input/Cursor;	f_5333905	f_5333905	
+	f	Z	f_7579809	appletMode	
+	f	Lorg/lwjgl/input/Cursor;	f_5333905	cursor	
 	f	I	f_0440810	f_0440810	
 	f	I	f_6184923	f_6184923	
 	f	Ljava/lang/String;	f_8370076	f_8370076	
 	f	Z	f_7113536		FULLSCREEN
 	m	()V	m_7502890	lockMouse	
 	m	()V	m_7834074	pauseGame	
-	m	(Ljava/lang/String;)V	m_0572353	m_0572353	
+	m	(Ljava/lang/String;)V	m_0572353	logGlError	
 		p	1		p_1	
 	m	(Ljava/awt/Canvas;IIZ)V	<init>	<init>	
 		p	1		p_1	
@@ -79,11 +79,11 @@ c	net/minecraft/unmapped/C_4766485	net/minecraft/client/render/TextRenderer
 		p	5		shadow	
 	m	(Ljava/lang/String;)I	m_3908105	getWidth	
 		p	1		text	
-	m	(Ljava/lang/String;III)V	m_4507504	m_4507504	
-		p	1		p_1	
+	m	(Ljava/lang/String;III)V	m_4507504	drawWithShadow	
+		p	1		text	
 		p	2		p_2	
 		p	3		p_3	
-		p	4		p_4	
+		p	4		color	
 	m	(Ljava/lang/String;Lnet/minecraft/unmapped/C_3385278;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	

--- a/mappings/c0.0.11a-launcher#rd-161348-launcher.tinydiff
+++ b/mappings/c0.0.11a-launcher#rd-161348-launcher.tinydiff
@@ -1,9 +1,9 @@
 tiny	2	0
 c	net/minecraft/unmapped/C_4078372	net/minecraft/world/WorldGenerator	
 	f	Ljava/util/Random;	f_3952515	random	
-	f	I	f_7275613	f_7275613	
-	f	I	f_8175346	f_8175346	
-	f	I	f_2316345	f_2316345	
+	f	I	f_7275613	sizeX	
+	f	I	f_8175346	sizeZ	
+	f	I	f_2316345	sizeY	
 	m	(III)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	

--- a/mappings/c0.0.12a_03#c0.0.11a-launcher.tinydiff
+++ b/mappings/c0.0.12a_03#c0.0.11a-launcher.tinydiff
@@ -173,7 +173,7 @@ c	net/minecraft/unmapped/C_0289174
 	m	()V	m_3430241		compile
 c	net/minecraft/unmapped/C_1044273
 	f	[Lnet/minecraft/unmapped/C_5283200;	f_9451185	sortedChunks	
-	f	I	f_0437423	f_0437423	
+	f	I	f_0437423	environmentGlLists	
 	f	F	f_3320356	prevCameraX	
 	f	F	f_1619923	prevCameraY	
 	f	F	f_4269846	prevCameraZ	

--- a/mappings/c0.0.12a_03#c0.0.11a-launcher.tinydiff
+++ b/mappings/c0.0.12a_03#c0.0.11a-launcher.tinydiff
@@ -34,8 +34,8 @@ c	net/minecraft/unmapped/C_3635204
 	f	F	f_7034990	maxX	
 	f	F	f_3247786	maxY	
 	f	F	f_3364884	maxZ	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1957938	f_1957938	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1788821	f_1788821	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1957938	WATER	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1788821	LAVA	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_2297673		AIR
 	f	Lnet/minecraft/unmapped/C_3635204;	f_8037066		COBBLESTONE
 	f	Lnet/minecraft/unmapped/C_3635204;	f_0374553		PLANKS
@@ -53,9 +53,9 @@ c	net/minecraft/unmapped/C_3635204
 	m	()I	m_9474325	getTickRate	
 	m	(Lnet/minecraft/unmapped/C_2334550;IIII)V	m_8901536	m_8901536	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
+		p	2		x	
+		p	3		y	
+		p	4		z	
 		p	5		p_5	
 	m	()Z	m_9310917	m_9310917	
 	m	(Lnet/minecraft/unmapped/C_0693652;Lnet/minecraft/unmapped/C_2334550;IIII)V	m_8104522	renderFace	

--- a/mappings/c0.0.13a-launcher#c0.0.12a_03.tinydiff
+++ b/mappings/c0.0.13a-launcher#c0.0.12a_03.tinydiff
@@ -132,7 +132,7 @@ c	net/minecraft/unmapped/C_6205974	net/minecraft/world/gen/noise/PerlinNoise
 c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_3172064;	f_8811754	session	
 	f	Lnet/minecraft/unmapped/C_0786431;	f_4327097	screen	
-	f	Lnet/minecraft/unmapped/C_9665058;	f_1737492	f_1737492	
+	f	Lnet/minecraft/unmapped/C_9665058;	f_1737492	worldStorage	
 	f	Lnet/minecraft/unmapped/C_4078372;	f_0254108	f_0254108	
 	f	Ljava/lang/String;	f_0125064	f_0125064	
 	f	Ljava/lang/String;	f_2284011	f_2284011	
@@ -189,8 +189,8 @@ c	net/minecraft/unmapped/C_0786431	net/minecraft/client/gui/screen/Screen
 	m	()V	m_1498751	handleMouse	
 	m	()V	m_7135145	tick	
 	m	(II)V	m_3426670	render	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		mouseX	
+		p	2		mouseY	
 	m	(IIIII)V	m_2880262	m_2880262	
 		p	1		p_1	
 		p	2		p_2	
@@ -237,7 +237,7 @@ c	net/minecraft/unmapped/C_1017062	net/minecraft/client/gui/screen/GameMenuScree
 c	net/minecraft/unmapped/C_1044273
 	f	I	f_3252359	f_3252359	
 	f	I	f_0774661	f_0774661	
-	m	()V	m_8889498	m_8889498	
+	m	()V	m_8889498	reload	
 	m	()Ljava/util/List;	m_6759097	m_6759097	
 	m	()V	m_5152808	m_5152808	
 	m	()V	m_4912347	m_4912347	
@@ -287,7 +287,7 @@ c	net/minecraft/unmapped/C_2621421	net/minecraft/client/gui/widget/ButtonWidget
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
-		p	5		p_5	
+		p	5		height	
 		p	6		p_6	
 c	net/minecraft/unmapped/C_2813741
 	m	(Lnet/minecraft/unmapped/C_5283200;Lnet/minecraft/unmapped/C_5283200;)I	m_8911644	m_8911644	
@@ -391,18 +391,18 @@ c	com/mojang/minecraft/MinecraftApplet$2322793		2322793
 c	net/minecraft/unmapped/C_7898033
 	m	(F)V	m_1101418	m_1101418	
 		p	1		p_1	
-c	net/minecraft/unmapped/C_9665058	net/minecraft/unmapped/C_9665058	
+c	net/minecraft/unmapped/C_9665058	net/minecraft/world/storage/WorldStorage	
 	f	I	f_7397851	f_7397851	
 	f	I	f_1846789	f_1846789	
-	f	Lnet/minecraft/unmapped/C_6108531;	f_7071680	f_7071680	
+	f	Lnet/minecraft/unmapped/C_6108531;	f_7071680	listener	
 	f	Ljava/lang/String;	f_1036795	f_1036795	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_7729189	m_7729189	
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_7729189	load	
 		p	1		p_1	
 		p	2		p_2	
 	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_2718498	m_2718498	
 		p	1		p_1	
 		p	2		p_2	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/OutputStream;)V	m_5611887	m_5611887	
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/OutputStream;)V	m_5611887	save	
 		p	1		p_1	
 		p	2		p_2	
 	m	(Lnet/minecraft/unmapped/C_6108531;)V	<init>	<init>	

--- a/mappings/c0.0.13a-launcher#c0.0.12a_03.tinydiff
+++ b/mappings/c0.0.13a-launcher#c0.0.12a_03.tinydiff
@@ -62,7 +62,7 @@ c	net/minecraft/unmapped/C_3635204
 		p	5			layer
 c	net/minecraft/unmapped/C_4078372
 	f	[I	f_6516890	f_6516890	
-	f	[B	f_8316515	f_8316515	
+	f	[B	f_8316515	blocks	
 	f	Lnet/minecraft/unmapped/C_6108531;	f_4854350	listener	
 	m	(IIIII)J	m_6366896	placeLake	
 		p	1		x	
@@ -71,7 +71,7 @@ c	net/minecraft/unmapped/C_4078372
 		p	4		maxY	
 		p	5		liquid	
 	m	()V	m_8370654	m_8370654	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;III)Z	m_0447977	m_0447977	
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;III)Z	m_0447977	generate	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	

--- a/mappings/c0.0.13a_03#c0.0.13a-launcher.tinydiff
+++ b/mappings/c0.0.13a_03#c0.0.13a-launcher.tinydiff
@@ -105,16 +105,16 @@ c	net/minecraft/unmapped/C_6205974
 		p	1			p_1
 c	net/minecraft/client/Minecraft
 	f	Ljava/lang/String;	f_1371651	hostAddress	
-	f	Ljava/lang/String;	f_6753290	f_6753290	
-	f	I	f_5242116	f_5242116	
+	f	Ljava/lang/String;	f_6753290	loadmapUser	
+	f	I	f_5242116	loadmapId	
 	f	Ljava/lang/String;	f_3100662	f_3100662	
 	f	Ljava/lang/String;	f_2284011		f_2284011
 	m	(Ljava/lang/String;)V	m_0572353
-		p	0		p_0	
+		p	0		message	
 		p	1			p_1
-	m	(Ljava/lang/String;I)Z	m_8752834	m_8752834	
-		p	1		p_1	
-		p	2		p_2	
+	m	(Ljava/lang/String;I)Z	m_8752834	loadWorld	
+		p	1		username	
+		p	2		slot	
 	m	(I)V	m_6284575	m_6284575	
 		p	1		p_1	
 	m	()V	m_1425842		m_1425842
@@ -219,7 +219,7 @@ c	net/minecraft/unmapped/C_2813741	net/minecraft/client/render/world/DistanceChu
 	m	(Lnet/minecraft/unmapped/C_0693652;)V	<init>
 		p	1		p_1	camera
 c	net/minecraft/unmapped/C_3172064
-	f	Ljava/lang/String;	f_1305529	f_1305529	
+	f	Ljava/lang/String;	f_1305529	id	
 	m	(Ljava/lang/String;Ljava/lang/String;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
@@ -265,7 +265,7 @@ c	net/minecraft/unmapped/C_1525636	net/minecraft/client/gui/screen/world/EnterWo
 	f	Ljava/lang/String;	f_5633768	title	
 	f	Ljava/lang/String;	f_0866064	name	
 	f	I	f_2617005	ticks	
-	f	I	f_6675555	f_6675555	
+	f	I	f_6675555	slot	
 	m	(Lnet/minecraft/unmapped/C_0786431;Ljava/lang/String;I)V	<init>	<init>	
 		p	1		parent	
 		p	2		name	
@@ -365,21 +365,21 @@ c	net/minecraft/unmapped/C_7898033
 	m	(F)V	m_1101418		m_1101418
 		p	1			p_1
 c	net/minecraft/unmapped/C_9665058
-	f	Lnet/minecraft/client/Minecraft;	f_7071680	f_7071680	
+	f	Lnet/minecraft/client/Minecraft;	f_7071680	listener	
 	f	I	f_7397851		f_7397851
 	f	I	f_1846789		f_1846789
-	f	Lnet/minecraft/unmapped/C_6108531;	f_7071680		f_7071680
+	f	Lnet/minecraft/unmapped/C_6108531;	f_7071680		listener
 	f	Ljava/lang/String;	f_1036795		f_1036795
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734	m_5551734	
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734	save	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
 		p	5		p_5	
 		p	6		p_6	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;I)Z	m_2468514	m_2468514	
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;I)Z	m_2468514	load	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	

--- a/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
+++ b/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
@@ -325,7 +325,7 @@ c	net/minecraft/unmapped/C_5853518
 c	net/minecraft/client/Minecraft
 	f	I	f_2615354	ticks	
 	f	I	f_7539337	lastClickTicks	
-	f	Ljava/awt/Robot;	f_9154570	f_9154570	
+	f	Ljava/awt/Robot;	f_9154570	robot	
 	f	Lcom/mojang/minecraft/level/Level;	f_5337597	world	
 	f	Lcom/mojang/minecraft/player/Player;	f_5473933	player	
 	f	F	f_9762585	f_9762585	
@@ -339,9 +339,9 @@ c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_0693652;	f_5473933		player
 	f	Ljava/util/ArrayList;	f_6333965		mobs
 	m	(I)V	m_6392526	createWorld	
-		p	1		p_1	
+		p	1		size	
 	m	(Lcom/mojang/minecraft/level/Level;)V	m_6427459	setWorld	
-		p	1		p_1	
+		p	1		world	
 	m	()V	m_5678101	handleMouseClick	
 	m	()V	m_5998520	m_5998520	
 	m	(ILjava/lang/String;)Z	m_7765695	m_7765695	
@@ -829,43 +829,43 @@ c	com/mojang/minecraft/player/Player	com/mojang/minecraft/player/Player
 		p	2		p_2	
 	m	()V	tick	tick	
 c	net/minecraft/unmapped/C_9665058
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734	m_5551734	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-		p	6		p_6	
-	m	(Ljava/lang/String;Ljava/lang/String;I)Lcom/mojang/minecraft/level/Level;	m_2468514	m_2468514	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_7729189	m_7729189	
-		p	1		p_1	
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/OutputStream;)V	m_5611887	m_5611887	
-		p	0		p_0	
-		p	1		p_1	
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734	save	
+		p	1		world	
+		p	2		hostAddress	
+		p	3		username	
+		p	4		sessionId	
+		p	5		name	
+		p	6		slot	
+	m	(Ljava/lang/String;Ljava/lang/String;I)Lcom/mojang/minecraft/level/Level;	m_2468514	load	
+		p	1		hostAddress	
+		p	2		username	
+		p	3		slot	
+	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_7729189	load	
+		p	1		input	
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/OutputStream;)V	m_5611887	save	
+		p	0		world	
+		p	1		output	
 	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_2718498	m_2718498	
 		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734		m_5551734
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734		save
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;I)Z	m_2468514		m_2468514
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;Ljava/lang/String;I)Z	m_2468514		load
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_7729189		m_7729189
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_7729189		load
 		p	1			p_1
 		p	2			p_2
 	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/InputStream;)Z	m_2718498		m_2718498
 		p	1			p_1
 		p	2			p_2
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/OutputStream;)V	m_5611887		m_5611887
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/io/OutputStream;)V	m_5611887		save
 		p	0			p_0
 		p	1			p_1
 c	com/mojang/minecraft/character/Zombie	com/mojang/minecraft/character/Zombie	

--- a/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
+++ b/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
@@ -88,11 +88,11 @@ c	net/minecraft/unmapped/C_3635204
 	f	Lnet/minecraft/unmapped/C_3635204;	f_7106883	SAND	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_7543153	GRAVEL	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_8676132	LOG	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_8866375	f_8866375	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_7230133	f_7230133	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_4107115	f_4107115	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_0069613	f_0069613	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_4511668	f_4511668	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_8866375	SAPLING	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_7230133	GOLD_ORE	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_4107115	IRON_ORE	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_0069613	COAL_ORE	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_4511668	LEAVES	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_4388356	f_4388356	
 	m	(III)Lcom/mojang/minecraft/phys/AABB;	m_9650578	getCollisionShape	
 		p	1		x	
@@ -106,11 +106,11 @@ c	net/minecraft/unmapped/C_3635204
 		p	4		z	
 		p	5		random	
 	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2454294;)V	m_3427045	addBreakParticles	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
+		p	1		world	
+		p	2		x	
+		p	3		y	
+		p	4		z	
+		p	5		particleManager	
 	m	(Lcom/mojang/minecraft/level/Level;IIII)V	m_9130741	neighborChanged	
 		c	Performs a block update. This method is called when a neighboring block has updated\n(i.e. placed, broken, or otherwise changed state).	
 		p	1		world	
@@ -219,10 +219,10 @@ c	net/minecraft/unmapped/C_3724278	net/minecraft/block/FallingBlock
 		p	3		p_3	
 		p	4		p_4	
 		p	5		p_5	
-	m	(Lcom/mojang/minecraft/level/Level;III)V	m_0416811	m_0416811	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
+	m	(Lcom/mojang/minecraft/level/Level;III)V	m_0416811	tryFall	
+		p	1		world	
+		p	2		x	
+		p	3		y	
 		p	0		p_0	
 c	net/minecraft/unmapped/C_4078372
 	m	(Ljava/lang/String;III)Lcom/mojang/minecraft/level/Level;	m_0447977	m_0447977	

--- a/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
+++ b/mappings/c0.0.14a_08#c0.0.13a_03-launcher.tinydiff
@@ -225,13 +225,13 @@ c	net/minecraft/unmapped/C_3724278	net/minecraft/block/FallingBlock
 		p	3		y	
 		p	0		p_0	
 c	net/minecraft/unmapped/C_4078372
-	m	(Ljava/lang/String;III)Lcom/mojang/minecraft/level/Level;	m_0447977	m_0447977	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-	m	(IIII)V	m_9667175	m_9667175	
-		p	1		p_1	
+	m	(Ljava/lang/String;III)Lcom/mojang/minecraft/level/Level;	m_0447977	generate	
+		p	1		name	
+		p	2		sizeX	
+		p	3		sizeZ	
+		p	4		sizeY	
+	m	(IIII)V	m_9667175	placeOre	
+		p	1		block	
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
@@ -239,7 +239,7 @@ c	net/minecraft/unmapped/C_4078372
 		p	1		p_1	
 	m	([I)V	m_1162242	m_1162242	
 		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;III)Z	m_0447977		m_0447977
+	m	(Lnet/minecraft/unmapped/C_6495127;Ljava/lang/String;III)Z	m_0447977		generate
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3

--- a/mappings/c0.0.15a#c0.0.14a_08.tinydiff
+++ b/mappings/c0.0.15a#c0.0.14a_08.tinydiff
@@ -43,14 +43,14 @@ c	net/minecraft/unmapped/C_8554894	net/minecraft/block/material/Material
 c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748	networkHandler	
 	f	F	f_9356698	f_9356698	
-	m	()Z	m_7044458	m_7044458	
+	m	()Z	m_7044458	isRemote	
 	m	(Ljava/lang/String;I)V	m_1909243	m_1909243	
 		p	1		p_1	
 		p	2		p_2	
 c	net/minecraft/unmapped/C_1044273
 	m	(Lcom/mojang/minecraft/player/Player;I)I	m_8682700	render	
 		p	1		p_1	
-		p	2		p_2	
+		p	2		layer	
 	m	(Lcom/mojang/minecraft/player/Player;I)V	m_8682700		render
 		p	1			p_1
 		p	2			p_2
@@ -159,5 +159,5 @@ c	net/minecraft/unmapped/C_8995754	net/minecraft/network/Connection
 		p	2		payload	
 	m	()V	m_1055827	m_1055827	
 c	net/minecraft/unmapped/C_9665058
-	m	(Ljava/io/InputStream;)[B	m_8590209	m_8590209	
-		p	0		p_0	
+	m	(Ljava/io/InputStream;)[B	m_8590209	readBlocks	
+		p	0		input	

--- a/mappings/c0.0.15a#c0.0.14a_08.tinydiff
+++ b/mappings/c0.0.15a#c0.0.14a_08.tinydiff
@@ -41,7 +41,7 @@ c	net/minecraft/unmapped/C_8554894	net/minecraft/block/material/Material
 	m	(I)V	<init>	<init>	
 		p	1		id	
 c	net/minecraft/client/Minecraft
-	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748	f_9951748	
+	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748	networkHandler	
 	f	F	f_9356698	f_9356698	
 	m	()Z	m_7044458	m_7044458	
 	m	(Ljava/lang/String;I)V	m_1909243	m_1909243	
@@ -109,54 +109,54 @@ c	com/mojang/minecraft/particle/Particle
 		p	6			p_6
 		p	7			p_7
 		p	8			p_8
-c	net/minecraft/unmapped/C_3464647	net/minecraft/unmapped/C_3464647	
-	f	Ljava/io/ByteArrayOutputStream;	f_1074422	f_1074422	
-	f	Lnet/minecraft/unmapped/C_8995754;	f_6951774	f_6951774	
+c	net/minecraft/unmapped/C_3464647	net/minecraft/client/network/ClientNetworkHandler	
+	f	Ljava/io/ByteArrayOutputStream;	f_1074422	output	
+	f	Lnet/minecraft/unmapped/C_8995754;	f_6951774	conection	
 	f	Lnet/minecraft/client/Minecraft;	f_1892126	f_1892126	
-	f	Ljava/util/HashMap;	f_4932152	f_4932152	
+	f	Ljava/util/HashMap;	f_4932152	players	
 	m	(Lnet/minecraft/client/Minecraft;Ljava/lang/String;ILjava/lang/String;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
-c	net/minecraft/unmapped/C_3600653	net/minecraft/unmapped/C_3600653	
-	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191	f_7217191	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308	f_3149308	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768	f_4461768	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207	f_5289207	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_8546696	f_8546696	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_2373056	f_2373056	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_3895897	f_3895897	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_7782816	f_7782816	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5917851	f_5917851	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_7798170	f_7798170	
-	f	I	f_7304734	f_7304734	
-	f	I	f_5406195	f_5406195	
-	f	B	f_6782781	f_6782781	
-	f	[Ljava/lang/Class;	f_8463791	f_8463791	
+c	net/minecraft/unmapped/C_3600653	net/minecraft/network/packet/Packet	
+	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191	PACKETS	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308	LOGIN	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768	PING	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207	WORLD_CHUNK	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_8546696	WORLD_SIZE	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_2373056	SET_BLOCK	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_3895897	BLOCK_UPDATE	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_7782816	ADD_PLAYER	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5917851	PLAYER_TELEPORT	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_7798170	REMOVE_PLAYER	
+	f	I	f_7304734	size	
+	f	I	f_5406195	lastId	
+	f	B	f_6782781	id	
+	f	[Ljava/lang/Class;	f_8463791	dataTypes	
 	m	([Ljava/lang/Class;)V	<init>	<init>	
-		p	1		p_1	
+		p	1		dataTypes	
 	m	()V	<clinit>	<clinit>	
 c	net/minecraft/unmapped/C_7898033
 	m	(FF)V	m_2584069	m_2584069	
 		p	1		p_1	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_8995754	net/minecraft/unmapped/C_8995754	
-	f	Z	f_8629289	f_8629289	
-	f	Ljava/nio/channels/SocketChannel;	f_6794126	f_6794126	
-	f	Ljava/nio/ByteBuffer;	f_1990451	f_1990451	
-	f	Ljava/nio/ByteBuffer;	f_4137365	f_4137365	
-	f	Lnet/minecraft/unmapped/C_3464647;	f_9596163	f_9596163	
-	f	Ljava/net/Socket;	f_0307332	f_0307332	
+c	net/minecraft/unmapped/C_8995754	net/minecraft/network/Connection	
+	f	Z	f_8629289	open	
+	f	Ljava/nio/channels/SocketChannel;	f_6794126	channel	
+	f	Ljava/nio/ByteBuffer;	f_1990451	input	
+	f	Ljava/nio/ByteBuffer;	f_4137365	output	
+	f	Lnet/minecraft/unmapped/C_3464647;	f_9596163	listener	
+	f	Ljava/net/Socket;	f_0307332	socket	
 	f	Z	f_3124921	f_3124921	
-	f	[B	f_8341920	f_8341920	
+	f	[B	f_8341920	stringBuffer	
 	m	(Ljava/lang/String;I)V	<init>	<init>	
-		p	1		p_1	
+		p	1		address	
 		p	2		p_2	
-	m	()V	m_3957784	m_3957784	
-	m	(Lnet/minecraft/unmapped/C_3600653;[Ljava/lang/Object;)V	m_9207877	m_9207877	
-		p	1		p_1	
-		p	2		p_2	
+	m	()V	m_3957784	close	
+	m	(Lnet/minecraft/unmapped/C_3600653;[Ljava/lang/Object;)V	m_9207877	send	
+		p	1		packet	
+		p	2		payload	
 	m	()V	m_1055827	m_1055827	
 c	net/minecraft/unmapped/C_9665058
 	m	(Ljava/io/InputStream;)[B	m_8590209	m_8590209	

--- a/mappings/c0.0.15a#c0.0.14a_08.tinydiff
+++ b/mappings/c0.0.15a#c0.0.14a_08.tinydiff
@@ -7,11 +7,11 @@ c	net/minecraft/unmapped/C_2682589
 		p	1			p_1
 		p	2			p_2
 c	net/minecraft/unmapped/C_3635204
-	f	[I	f_0375741	f_0375741	
-	f	F	f_8697106	f_8697106	
+	f	[I	f_0375741	BRIGHTNESS	
+	f	F	f_8697106	weight	
 	m	()Lnet/minecraft/unmapped/C_8554894;	m_5824613	getMaterial	
-	m	(I)V	m_5930259	m_5930259	
-		p	1		p_1	
+	m	(I)V	m_5930259	setBrightness	
+		p	1		brightness	
 	m	(Lcom/mojang/minecraft/level/Level;III)F	m_1598263	getBrightness	
 		p	1		world	
 		p	2		x	

--- a/mappings/c0.0.15a#c0.0.14a_08.tinydiff
+++ b/mappings/c0.0.15a#c0.0.14a_08.tinydiff
@@ -120,7 +120,7 @@ c	net/minecraft/unmapped/C_3464647	net/minecraft/client/network/ClientNetworkHan
 		p	3		p_3	
 		p	4		p_4	
 c	net/minecraft/unmapped/C_3600653	net/minecraft/network/packet/Packet	
-	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191	PACKETS	
+	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191	BY_ID	
 	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308	LOGIN	
 	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768	PING	
 	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207	WORLD_CHUNK	

--- a/mappings/c0.0.16a_02#c0.0.15a.tinydiff
+++ b/mappings/c0.0.16a_02#c0.0.15a.tinydiff
@@ -92,21 +92,21 @@ c	com/mojang/minecraft/net/NetworkPlayer
 		p	7			p_7
 		p	8			p_8
 c	net/minecraft/unmapped/C_3464647
-	m	(IIIII)V	m_8042486	m_8042486	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
+	m	(IIIII)V	m_8042486	setBlock	
+		p	1		x	
+		p	2		y	
+		p	3		z	
+		p	4		mode	
+		p	5		block	
 c	net/minecraft/unmapped/C_3600653
-	f	Lnet/minecraft/unmapped/C_3600653;	f_6187456	f_6187456	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_9528793	f_9528793	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_6653682	f_6653682	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_0872420	f_0872420	
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5317033	f_5317033	
-c	net/minecraft/unmapped/C_5169041	net/minecraft/unmapped/C_5169041	
-	f	Ljava/lang/String;	f_0533128	f_0533128	
-	f	I	f_9208767	f_9208767	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_6187456	PLAYER_MOVE	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_9528793	PLAYER_VELOCITY	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_6653682	PLAYER_ROTATE	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_0872420	MESSAGE	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5317033	DISCONNECT	
+c	net/minecraft/unmapped/C_5169041	net/minecraft/client/gui/screen/ChatScreen	
+	f	Ljava/lang/String;	f_0533128	lastChatMessage	
+	f	I	f_9208767	ticks	
 	m	()V	<init>	<init>	
 	m	()V	m_2060594	m_2060594	
 	m	()V	m_5056964	m_5056964	
@@ -117,14 +117,14 @@ c	net/minecraft/unmapped/C_5169041	net/minecraft/unmapped/C_5169041
 	m	(II)V	m_3426670	m_3426670	
 		p	1		p_1	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_7018681	net/minecraft/unmapped/C_7018681	
-	f	F	f_6477721	f_6477721	
-	f	F	f_7870468	f_7870468	
-	f	F	f_0110066	f_0110066	
-	f	F	f_2382842	f_2382842	
-	f	F	f_1369203	f_1369203	
-	f	Z	f_5972456	f_5972456	
-	f	Z	f_9167360	f_9167360	
+c	net/minecraft/unmapped/C_7018681	net/minecraft/entity/mob/player/PlayerTransform	
+	f	F	f_6477721	x	
+	f	F	f_7870468	y	
+	f	F	f_0110066	z	
+	f	F	f_2382842	yaw	
+	f	F	f_1369203	pitch	
+	f	Z	f_5972456	position	
+	f	Z	f_9167360	rotation	
 	m	(FFFFF)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
@@ -147,8 +147,8 @@ c	net/minecraft/unmapped/C_7898033
 		p	1			p_1
 		p	2			p_2
 c	net/minecraft/unmapped/C_8995754
-	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968	m_9294968	
-		p	1		p_1	
+	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968	read	
+		p	1		type	
 c	net/minecraft/unmapped/C_9437404	net/minecraft/unmapped/C_9437404	
 	f	Ljava/lang/String;	f_4623692	f_4623692	
 	f	I	f_5528963	f_5528963	

--- a/mappings/c0.0.16a_02#c0.0.15a.tinydiff
+++ b/mappings/c0.0.16a_02#c0.0.15a.tinydiff
@@ -1,8 +1,8 @@
 tiny	2	0
 c	net/minecraft/client/Minecraft
 	f	Ljava/lang/String;	f_9991059	startupServerAddress	
-	f	Z	f_4909729	f_4909729	
-	f	I	f_0132506	f_0132506	
+	f	Z	f_4909729	skipGameRender	
+	f	I	f_0132506	startupServerPort	
 	f	Ljava/util/List;	f_0525575	f_0525575	
 	m	()V	m_2422356	m_2422356	
 	m	()V	m_1963333	setupFog	
@@ -25,7 +25,7 @@ c	net/minecraft/unmapped/C_4643161	net/minecraft/client/gui/screen/FatalErrorScr
 		p	1		p_1	
 		p	2		p_2	
 c	net/minecraft/unmapped/C_4766485
-	m	(Ljava/lang/String;III)V	m_5762160	m_5762160	
+	m	(Ljava/lang/String;III)V	m_5762160	draw	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
@@ -149,8 +149,8 @@ c	net/minecraft/unmapped/C_7898033
 c	net/minecraft/unmapped/C_8995754
 	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968	read	
 		p	1		type	
-c	net/minecraft/unmapped/C_9437404	net/minecraft/unmapped/C_9437404	
-	f	Ljava/lang/String;	f_4623692	f_4623692	
-	f	I	f_5528963	f_5528963	
+c	net/minecraft/unmapped/C_9437404	net/minecraft/client/gui/ChatMessage	
+	f	Ljava/lang/String;	f_4623692	text	
+	f	I	f_5528963	age	
 	m	(Ljava/lang/String;)V	<init>	<init>	
 		p	1		p_1	

--- a/mappings/c0.0.17a#c0.0.16a_02.tinydiff
+++ b/mappings/c0.0.17a#c0.0.16a_02.tinydiff
@@ -30,7 +30,7 @@ c	net/minecraft/unmapped/C_1044273
 	m	(Lcom/mojang/minecraft/level/Level;)V	m_9815508		m_9815508
 		p	1			p_1
 c	net/minecraft/unmapped/C_3172064
-	f	Ljava/lang/String;	f_2577321	f_2577321	
+	f	Ljava/lang/String;	f_2577321	password	
 	f	[I	f_7459865	f_7459865	
 	m	()V	<clinit>	<clinit>	
 c	net/minecraft/unmapped/C_5283200
@@ -39,7 +39,7 @@ c	net/minecraft/unmapped/C_5283200
 		p	2		originX	
 		p	3		originY	
 		p	4		originZ	
-		p	5		p_5	
+		p	5		size	
 		p	6		glList	
 	m	(Lcom/mojang/minecraft/level/Level;IIII)V	<init>		<init>
 		p	1			world

--- a/mappings/c0.0.17a#c0.0.16a_02.tinydiff
+++ b/mappings/c0.0.17a#c0.0.16a_02.tinydiff
@@ -82,16 +82,16 @@ c	com/mojang/minecraft/particle/Particle
 		p	6			forwards
 		p	7			sideways
 c	net/minecraft/unmapped/C_3464647
-	f	Z	f_7137415	f_7137415	
+	f	Z	f_7137415	connected	
 	m	(Lnet/minecraft/client/Minecraft;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-	m	(Ljava/lang/Exception;)V	m_3938439	m_3938439	
-		p	1		p_1	
-	m	()Z	m_3898071	m_3898071	
+		p	2		address	
+		p	3		port	
+		p	4		username	
+		p	5		password	
+	m	(Ljava/lang/Exception;)V	m_3938439	handleException	
+		p	1		exception	
+	m	()Z	m_3898071	isConnected	
 	m	(Lnet/minecraft/client/Minecraft;Ljava/lang/String;ILjava/lang/String;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2

--- a/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
+++ b/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
@@ -88,13 +88,13 @@ c	net/minecraft/unmapped/C_3544790	net/minecraft/client/render/texture/DynamicTe
 c	net/minecraft/unmapped/C_3699792	net/minecraft/client/gui/GameGui	
 	f	Ljava/util/List;	f_9851646	chatMessages	
 	f	Lnet/minecraft/client/Minecraft;	f_5266056	minecraft	
-	f	I	f_0775750	f_0775750	
-	f	I	f_8519063	f_8519063	
+	f	I	f_0775750	width	
+	f	I	f_8519063	height	
 	m	(Lnet/minecraft/client/Minecraft;II)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-	m	()V	m_1122306	m_1122306	
+		p	2		width	
+		p	3		height	
+	m	()V	m_1122306	render	
 	m	(IIIIII)V	m_6628097	m_6628097	
 		p	0		p_0	
 		p	1		p_1	

--- a/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
+++ b/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
@@ -4,7 +4,7 @@ c	net/minecraft/unmapped/C_0456473
 	m	(IIZ)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
-		p	3		p_3	
+		p	3		culling	
 	m	(Lcom/mojang/minecraft/level/Level;IIIII)Z	m_8199947	m_8199947	
 		p	1		p_1	
 		p	2		p_2	
@@ -49,12 +49,12 @@ c	net/minecraft/unmapped/C_7450537	net/minecraft/block/SpongeBlock
 		p	3		p_3	
 		p	4		p_4	
 c	net/minecraft/unmapped/C_8443484	net/minecraft/block/TransparentBlock	
-	f	Z	f_1686264	f_1686264	
+	f	Z	f_1686264	culling	
 	m	()Z	m_1944525	m_1944525	
 	m	(IIZ)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
+		p	1		id	
+		p	2		sprite	
+		p	3		culling	
 	m	()Z	m_3237591	m_3237591	
 	m	(Lcom/mojang/minecraft/level/Level;IIIII)Z	m_8199947	m_8199947	
 		p	1		p_1	

--- a/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
+++ b/mappings/c0.0.19a_04#c0.0.18a_02.tinydiff
@@ -145,7 +145,7 @@ c	com/mojang/minecraft/level/Level
 c	com/mojang/minecraft/net/NetworkPlayer
 	f	I	tickCount	tickCount	
 c	net/minecraft/unmapped/C_3464647
-	f	Z	f_1094396	f_1094396	
+	f	Z	f_1094396	loaded	
 c	net/minecraft/unmapped/C_7898033
 	m	(FFFFF)V	m_2584069	m_2584069	
 		p	1		p_1	

--- a/mappings/c0.0.20a_01#c0.0.19a_06.tinydiff
+++ b/mappings/c0.0.20a_01#c0.0.19a_06.tinydiff
@@ -30,8 +30,8 @@ c	net/minecraft/unmapped/C_3635204
 	f	Lnet/minecraft/unmapped/C_3635204;	f_3027250	RED_FLOWER	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_4214731	BROWN_MUSHROOM	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_1176361	RED_MUSHROOM	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_5091096	f_5091096	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_3504882	f_3504882	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_5091096	COBBLESTONE	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_3504882	GOLD_BLOCK	
 c	net/minecraft/client/Minecraft
 	f	I	f_9363735		selectedBlock
 	m	(Z)V	m_6824580	m_6824580	

--- a/mappings/c0.0.20a_01#c0.0.19a_06.tinydiff
+++ b/mappings/c0.0.20a_01#c0.0.19a_06.tinydiff
@@ -38,7 +38,7 @@ c	net/minecraft/client/Minecraft
 		p	1		p_1	
 c	net/minecraft/unmapped/C_0289174
 	m	(F)V	m_8346450	render	
-		p	1		p_1	
+		p	1		scale	
 	m	()V	m_8346450		render
 c	net/minecraft/unmapped/C_0786431
 	m	(III)V	m_9746540	mouseClicked	

--- a/mappings/c0.0.22a_05#c0.0.21a.tinydiff
+++ b/mappings/c0.0.22a_05#c0.0.21a.tinydiff
@@ -17,8 +17,8 @@ c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_8425960;	f_5341632	progressRenderer	
 	f	Lnet/minecraft/unmapped/C_4824661;	f_9540840	gameRenderer	
 	f	Lnet/minecraft/unmapped/C_0139979;	f_3881621	resourceDownloader	
-	f	Lnet/minecraft/unmapped/C_7598507;	f_2497216	f_2497216	
-	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934	f_1501934	
+	f	Lnet/minecraft/unmapped/C_7598507;	f_2497216	sounds	
+	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934	soundEngine	
 	f	Ljava/nio/FloatBuffer;	f_2682162		fogColor
 	f	Ljava/nio/FloatBuffer;	f_4839363		shadowFogColor
 	f	F	f_9762585		f_9762585
@@ -180,12 +180,12 @@ c	net/minecraft/unmapped/C_0091050	de/jarnbjo/vorbis/Residue
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073	getLook	
 		p	1		source	
 		p	2		key	
-c	net/minecraft/unmapped/C_0190332	net/minecraft/unmapped/C_0190332	
+c	net/minecraft/unmapped/C_0190332	net/minecraft/client/sound/VorbisCodec	
 	m	()V	<init>	<init>	
-	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032	m_3617032	
+	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032	load	
 		p	0		p_0	
 c	net/minecraft/unmapped/C_0322130	de/jarnbjo/vorbis/VorbisStream	
-	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447	f_3883447	
+	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447	oggStream	
 	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360	identificationHeader	
 	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945	commentHeader	
 	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100	setupHeader	
@@ -221,14 +221,14 @@ c	net/minecraft/unmapped/C_1133045	de/jarnbjo/vorbis/Mapping0
 	m	()[I	m_9055268	m_9055268	
 	m	()I	m_9681215	m_9681215	
 	m	()I	m_6247361	m_6247361	
-c	net/minecraft/unmapped/C_1602975	net/minecraft/unmapped/C_1602975	
-	f	Lnet/minecraft/unmapped/C_6857610;	f_0567509	f_0567509	
-	f	F	f_3867104	f_3867104	
-	f	F	f_0155570	f_0155570	
+c	net/minecraft/unmapped/C_1602975	net/minecraft/client/sound/buffer/SimpleSoundBuffer	
+	f	Lnet/minecraft/unmapped/C_6857610;	f_0567509	sound	
+	f	F	f_3867104	position	
+	f	F	f_0155570	pitch	
 	m	(Lnet/minecraft/unmapped/C_6857610;FF)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
+		p	2		pitch	
+		p	3		volume	
 	m	([SI)I	m_2841446	m_2841446	
 		p	1		p_1	
 		p	2		p_2	
@@ -285,11 +285,11 @@ c	net/minecraft/unmapped/C_1861953	de/jarnbjo/ogg/OggPage
 		p	0		source	
 		p	1		buffer	
 	m	()I	m_4618783	getTotalLength	
-c	net/minecraft/unmapped/C_1996769	net/minecraft/unmapped/C_1996769	
-	m	([I[II)Z	m_6552350	m_6552350	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
+c	net/minecraft/unmapped/C_1996769	net/minecraft/client/sound/source/SoundSource	
+	m	([I[II)Z	m_6552350	play	
+		p	1		leftChannel	
+		p	2		rightChannel	
+		p	3		sampleCount	
 c	net/minecraft/unmapped/C_2122471	de/jarnbjo/vorbis/Util	
 	m	()V	<init>	<init>	
 	m	(I)I	m_3224692	ilog	
@@ -348,7 +348,7 @@ c	net/minecraft/unmapped/C_4811676	de/jarnbjo/vorbis/Residue2
 		p	5		p_5	
 	m	()Ljava/lang/Object;	clone	clone	
 c	net/minecraft/unmapped/C_4958210	de/jarnbjo/ogg/LogicalOggStreamImpl	
-	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799	f_9154799	
+	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799	source	
 	f	Ljava/util/ArrayList;	f_2795626	pageNumberMapping	
 	f	I	f_4763122	pageIndex	
 	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523	currentPage	
@@ -368,7 +368,7 @@ c	net/minecraft/unmapped/C_5664626	de/jarnbjo/vorbis/CodeBook
 	m	([I)Z	m_8448942	createHuffmanTree	
 		p	1		entryLengths	
 c	net/minecraft/unmapped/C_5718344	de/jarnbjo/vorbis/MdctFloat	
-	f	I	f_3569804	f_3569804	
+	f	I	f_3569804	n	
 	f	I	f_7581426	log2n	
 	f	[F	f_4416437	trig	
 	f	[I	f_3575069	bitrev	
@@ -418,15 +418,15 @@ c	net/minecraft/unmapped/C_5765318	de/jarnbjo/vorbis/Floor1
 		p	1		p_1	
 	m	()Ljava/lang/Object;	clone	clone	
 	m	()V	<clinit>	<clinit>	
-c	net/minecraft/unmapped/C_5791831	net/minecraft/unmapped/C_5791831	
-	f	Ljava/nio/ByteBuffer;	f_1311242	f_1311242	
-	f	Ljava/nio/ByteBuffer;	f_9842249	f_9842249	
-	f	Ljava/nio/ByteBuffer;	f_0920360	f_0920360	
-	f	Ljava/nio/ByteBuffer;	f_9322493	f_9322493	
-	f	Lnet/minecraft/unmapped/C_0322130;	f_6710886	f_6710886	
-	f	Lnet/minecraft/unmapped/C_8534347;	f_9139123	f_9139123	
-	f	Z	f_5499651	f_5499651	
-	f	Z	f_1930601	f_1930601	
+c	net/minecraft/unmapped/C_5791831	net/minecraft/client/sound/source/StreamingSoundSource	
+	f	Ljava/nio/ByteBuffer;	f_1311242	vorbisBuffer	
+	f	Ljava/nio/ByteBuffer;	f_9842249	lastBuffer	
+	f	Ljava/nio/ByteBuffer;	f_0920360	currentBuffer	
+	f	Ljava/nio/ByteBuffer;	f_9322493	nextBuffer	
+	f	Lnet/minecraft/unmapped/C_0322130;	f_6710886	vorbis	
+	f	Lnet/minecraft/unmapped/C_8534347;	f_9139123	engine	
+	f	Z	f_5499651	finished	
+	f	Z	f_1930601	terminated	
 	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/net/URL;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
@@ -439,11 +439,11 @@ c	net/minecraft/unmapped/C_5791831$7680210	7680210
 	m	(Lnet/minecraft/unmapped/C_5791831;)V	<init>	<init>	
 		p	1		p_1	
 	m	()V	run	run	
-c	net/minecraft/unmapped/C_6786807	net/minecraft/unmapped/C_6786807	
-	f	Lcom/mojang/minecraft/Entity;	f_4225044	f_4225044	
+c	net/minecraft/unmapped/C_6786807	net/minecraft/client/sound/effect/EntitySoundEffect	
+	f	Lcom/mojang/minecraft/Entity;	f_4225044	source	
 	m	(Lcom/mojang/minecraft/Entity;Lcom/mojang/minecraft/Entity;)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
+		p	2		listener	
 	m	()F	m_4192289	m_4192289	
 	m	()F	m_2230278	m_2230278	
 c	net/minecraft/unmapped/C_6848444	de/jarnbjo/vorbis/Floor	
@@ -458,9 +458,9 @@ c	net/minecraft/unmapped/C_6848444	de/jarnbjo/vorbis/Floor
 	m	([F)V	m_5525230	computeFloor	
 		p	1		vector	
 	m	()V	<clinit>	<clinit>	
-c	net/minecraft/unmapped/C_6857610	net/minecraft/unmapped/C_6857610	
-	f	[S	f_2102733	f_2102733	
-	f	F	f_0816698	f_0816698	
+c	net/minecraft/unmapped/C_6857610	net/minecraft/client/sound/Sound	
+	f	[S	f_2102733	samples	
+	f	F	f_0816698	sampleRate	
 	m	([SF)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
@@ -477,9 +477,9 @@ c	net/minecraft/unmapped/C_6908252	de/jarnbjo/vorbis/Mapping
 	m	()[I	m_9055268	getSubmapResidues	
 	m	()I	m_9681215	getCouplingSteps	
 	m	()I	m_6247361	getSubmaps	
-c	net/minecraft/unmapped/C_6975176	net/minecraft/unmapped/C_6975176	
-	m	()F	m_4192289	m_4192289	
-	m	()F	m_2230278	m_2230278	
+c	net/minecraft/unmapped/C_6975176	net/minecraft/client/sound/effect/SoundEffect	
+	m	()F	m_4192289	getPan	
+	m	()F	m_2230278	getVolume	
 c	net/minecraft/unmapped/C_7120212	net/minecraft/block/BlockSound	
 	f	Lnet/minecraft/unmapped/C_7120212;	f_0972575	NONE	
 	f	Lnet/minecraft/unmapped/C_7120212;	f_2134264	GRASS	
@@ -504,54 +504,54 @@ c	net/minecraft/unmapped/C_7120212	net/minecraft/block/BlockSound
 	m	()F	m_8797914	getVolume	
 	m	()F	m_2550154	getPitch	
 	m	()V	<clinit>	<clinit>	
-c	net/minecraft/unmapped/C_7217122	net/minecraft/unmapped/C_7217122	
-	f	F	f_6751841	f_6751841	
+c	net/minecraft/unmapped/C_7217122	net/minecraft/client/sound/buffer/SoundBuffer	
+	f	F	f_6751841	volume	
 	m	()V	<init>	<init>	
-	m	([SI)I	m_2841446	m_2841446	
-		p	1		p_1	
-		p	2		p_2	
-c	net/minecraft/unmapped/C_7421241	net/minecraft/unmapped/C_7421241	
-	f	F	f_7913003	f_7913003	
-	f	F	f_5482103	f_5482103	
-	f	F	f_9948499	f_9948499	
+	m	([SI)I	m_2841446	read	
+		p	1		samples	
+		p	2		sampleCount	
+c	net/minecraft/unmapped/C_7421241	net/minecraft/client/sound/effect/PositionSoundEffect	
+	f	F	f_7913003	x	
+	f	F	f_5482103	y	
+	f	F	f_9948499	z	
 	m	(FFFLcom/mojang/minecraft/Entity;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
-		p	4		p_4	
+		p	4		listener	
 	m	()F	m_4192289	m_4192289	
 	m	()F	m_2230278	m_2230278	
-c	net/minecraft/unmapped/C_7518437	net/minecraft/unmapped/C_7518437	
-	f	Lcom/mojang/minecraft/Entity;	f_5561345	f_5561345	
+c	net/minecraft/unmapped/C_7518437	net/minecraft/client/sound/effect/StereoSoundEffect	
+	f	Lcom/mojang/minecraft/Entity;	f_5561345	listener	
 	m	(Lcom/mojang/minecraft/Entity;)V	<init>	<init>	
 		p	1		p_1	
-	m	(FF)F	m_0724724	m_0724724	
-		p	1		p_1	
-		p	2		p_2	
-	m	(FFF)F	m_5736595	m_5736595	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-c	net/minecraft/unmapped/C_7598507	net/minecraft/unmapped/C_7598507	
-	f	Lnet/minecraft/unmapped/C_0190332;	f_7276700	f_7276700	
-	f	Ljava/util/Map;	f_7131455	f_7131455	
-	f	Ljava/util/Map;	f_1040873	f_1040873	
-	f	Ljava/util/Random;	f_9006459	f_9006459	
-	f	J	f_8766128	f_8766128	
+	m	(FF)F	m_0724724	getPan	
+		p	1		x	
+		p	2		z	
+	m	(FFF)F	m_5736595	getVolume	
+		p	1		x	
+		p	2		y	
+		p	3		z	
+c	net/minecraft/unmapped/C_7598507	net/minecraft/client/sound/Sounds	
+	f	Lnet/minecraft/unmapped/C_0190332;	f_7276700	codec	
+	f	Ljava/util/Map;	f_7131455	sounds	
+	f	Ljava/util/Map;	f_1040873	records	
+	f	Ljava/util/Random;	f_9006459	random	
+	f	J	f_8766128	musicTime	
 	m	()V	<init>	<init>	
-	m	(Ljava/lang/String;FF)Lnet/minecraft/unmapped/C_7217122;	m_5004797	m_5004797	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-	m	(Ljava/io/File;Ljava/lang/String;)V	m_6216168	m_6216168	
-		p	1		p_1	
-		p	2		p_2	
-	m	(Ljava/lang/String;Ljava/io/File;)V	m_1222136	m_1222136	
-		p	1		p_1	
-		p	2		p_2	
-	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/lang/String;)Z	m_6859432	m_6859432	
-		p	1		p_1	
-		p	2		p_2	
+	m	(Ljava/lang/String;FF)Lnet/minecraft/unmapped/C_7217122;	m_5004797	getRandom	
+		p	1		path	
+		p	2		volume	
+		p	3		pitch	
+	m	(Ljava/io/File;Ljava/lang/String;)V	m_6216168	add	
+		p	1		file	
+		p	2		path	
+	m	(Ljava/lang/String;Ljava/io/File;)V	m_1222136	addRecord	
+		p	1		path	
+		p	2		file	
+	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/lang/String;)Z	m_6859432	playRandomRecord	
+		p	1		engine	
+		p	2		path	
 c	net/minecraft/unmapped/C_7900390	de/jarnbjo/util/io/ByteArrayBitInputStream	
 	f	[B	f_8612550	source	
 	f	B	f_8992957	currentByte	
@@ -599,15 +599,15 @@ c	net/minecraft/unmapped/C_8423483	de/jarnbjo/vorbis/AudioPacket
 		p	1		previousPacket	
 		p	2		buffer	
 	m	()V	<clinit>	<clinit>	
-c	net/minecraft/unmapped/C_8534347	net/minecraft/unmapped/C_8534347	
-	f	Z	f_3030770	f_3030770	
-	f	Ljavax/sound/sampled/SourceDataLine;	f_9674275	f_9674275	
-	f	Ljava/util/List;	f_0650018	f_0650018	
+c	net/minecraft/unmapped/C_8534347	net/minecraft/client/sound/SoundEngine	
+	f	Z	f_3030770	running	
+	f	Ljavax/sound/sampled/SourceDataLine;	f_9674275	audioDataLine	
+	f	Ljava/util/List;	f_0650018	sources	
 	f	Z	f_5920001	f_5920001	
-	m	(Lnet/minecraft/unmapped/C_1996769;)V	m_3604784	m_3604784	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	m_5327400	m_5327400	
-		p	1		p_1	
+	m	(Lnet/minecraft/unmapped/C_1996769;)V	m_3604784	play	
+		p	1		source	
+	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	m_5327400	play	
+		p	1		buffer	
 		p	2		p_2	
 	m	()V	run	run	
 	m	()V	<init>	<init>	
@@ -635,12 +635,12 @@ c	net/minecraft/unmapped/C_8903842	de/jarnbjo/vorbis/CommentHeader
 		p	0		source	
 c	net/minecraft/unmapped/C_8995754
 	m	()V	m_1055827		m_1055827
-c	net/minecraft/unmapped/C_9158347	net/minecraft/unmapped/C_9158347	
-	f	Lnet/minecraft/unmapped/C_7217122;	f_9317684	f_9317684	
-	f	Lnet/minecraft/unmapped/C_6975176;	f_4348730	f_4348730	
-	f	F	f_1051437	f_1051437	
-	f	F	f_2764470	f_2764470	
-	f	[S	f_6950351	f_6950351	
+c	net/minecraft/unmapped/C_9158347	net/minecraft/client/sound/source/SimpleSoundSource	
+	f	Lnet/minecraft/unmapped/C_7217122;	f_9317684	buffer	
+	f	Lnet/minecraft/unmapped/C_6975176;	f_4348730	effect	
+	f	F	f_1051437	pan	
+	f	F	f_2764470	volume	
+	f	[S	f_6950351	sampleBuffer	
 	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	

--- a/mappings/c0.0.22a_05#c0.0.21a.tinydiff
+++ b/mappings/c0.0.22a_05#c0.0.21a.tinydiff
@@ -83,34 +83,34 @@ c	net/minecraft/unmapped/C_0139979	net/minecraft/client/resource/ResourceDownloa
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_0786431
-	m	()V	m_0614547	m_0614547	
+	m	()V	m_0614547	handleInputs	
 c	net/minecraft/unmapped/C_2454294
-	m	()V	m_4221773	m_4221773	
+	m	()V	m_4221773	tick	
 c	net/minecraft/unmapped/C_3699792
-	m	(Ljava/lang/String;)V	m_6992985	m_6992985	
-		p	1		p_1	
+	m	(Ljava/lang/String;)V	m_6992985	addMessage	
+		p	1		content	
 c	net/minecraft/unmapped/C_4824661	net/minecraft/client/render/GameRenderer	
 	f	Lnet/minecraft/client/Minecraft;	f_8246436	minecraft	
 	f	I	f_5289597	f_5289597	
 	f	I	f_7860895	f_7860895	
 	f	Ljava/nio/FloatBuffer;	f_4117573	floatBuffer	
 	f	Z	f_3616371	displayActive	
-	f	F	f_9070619	f_9070619	
-	f	F	f_3370476	f_3370476	
-	f	F	f_9901150	f_9901150	
-	f	F	f_6447311	f_6447311	
-	f	F	f_3735549	f_3735549	
+	f	F	f_9070619	fogBrightness	
+	f	F	f_3370476	renderDistance	
+	f	F	f_9901150	fogRed	
+	f	F	f_6447311	fogGreen	
+	f	F	f_3735549	fogBlue	
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		minecraft	
 	m	()V	m_4946406	setupGuiState	
-	m	(Z)V	m_2557984	m_2557984	
-		p	1		p_1	
-	m	()V	m_6382667	m_6382667	
-	m	(FFFF)Ljava/nio/FloatBuffer;	m_2787702	m_2787702	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
+	m	(Z)V	m_2557984	setLighting	
+		p	1		enable	
+	m	()V	m_6382667	setupFog	
+	m	(FFFF)Ljava/nio/FloatBuffer;	m_2787702	getBuffer	
+		p	1		f1	
+		p	2		f2	
+		p	3		f3	
+		p	4		f4	
 c	net/minecraft/unmapped/C_8425960	net/minecraft/client/render/ProgressRenderer	
 	f	Ljava/lang/String;	f_1486409	stage	
 	f	Lnet/minecraft/client/Minecraft;	f_4801953	minecraft	
@@ -119,10 +119,10 @@ c	net/minecraft/unmapped/C_8425960	net/minecraft/client/render/ProgressRenderer
 		p	1		minecraft	
 	m	(Ljava/lang/String;)V	m_3915830	progressStage	
 		p	1		stage	
-	m	(I)V	m_1991224	progressPercentage	
+	m	(I)V	m_1991224	progressStagePercentage	
 		p	1		percentage	
-	m	(Ljava/lang/String;)V	m_1434192	m_1434192	
-		p	1		p_1	
+	m	(Ljava/lang/String;)V	m_1434192	progressStart	
+		p	1		title	
 c	com/mojang/minecraft/Entity
 	f	F	walkDist	walkDist	
 	f	Z	makeStepSound	makeStepSound	
@@ -650,8 +650,8 @@ c	net/minecraft/unmapped/C_9158347	net/minecraft/unmapped/C_9158347
 		p	3		p_3	
 	m	()V	<clinit>	<clinit>	
 c	net/minecraft/unmapped/C_9665058
-	f	Lnet/minecraft/unmapped/C_8425960;	f_7071680	f_7071680	
-	f	Lnet/minecraft/client/Minecraft;	f_7071680		f_7071680
+	f	Lnet/minecraft/unmapped/C_8425960;	f_7071680	listener	
+	f	Lnet/minecraft/client/Minecraft;	f_7071680		listener
 	m	(Lnet/minecraft/unmapped/C_8425960;)V	<init>	<init>	
 		p	1		p_1	
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>		<init>

--- a/mappings/c0.0.22a_05#c0.0.21a.tinydiff
+++ b/mappings/c0.0.22a_05#c0.0.21a.tinydiff
@@ -146,74 +146,74 @@ c	com/mojang/minecraft/level/Level
 		p	4		p_4	
 		p	5		p_5	
 		p	6		p_6	
-c	net/minecraft/unmapped/C_0091050	net/minecraft/unmapped/C_0091050	
-	f	I	f_6751262	f_6751262	
-	f	I	f_1842919	f_1842919	
-	f	I	f_0262118	f_0262118	
-	f	I	f_9191803	f_9191803	
-	f	I	f_6604920	f_6604920	
-	f	[I	f_6243398	f_6243398	
-	f	[[I	f_1032081	f_1032081	
-	f	Ljava/util/HashMap;	f_4109781	f_4109781	
+c	net/minecraft/unmapped/C_0091050	de/jarnbjo/vorbis/Residue	
+	f	I	f_6751262	begin	
+	f	I	f_1842919	end	
+	f	I	f_0262118	partitionSize	
+	f	I	f_9191803	classifications	
+	f	I	f_6604920	classBook	
+	f	[I	f_6243398	cascade	
+	f	[[I	f_1032081	books	
+	f	Ljava/util/HashMap;	f_4109781	looks	
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_0091050;	m_5224066	m_5224066	
-		p	0		p_0	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_2214843;[Z[[F)V	m_8112343	m_8112343	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-	m	()I	m_7334930	m_7334930	
-	m	()I	m_5680415	m_5680415	
-	m	()I	m_0954887	m_0954887	
-	m	()I	m_8900682	m_8900682	
-	m	()I	m_6433054	m_6433054	
-	m	()[I	m_3528011	m_3528011	
-	m	()[[I	m_7464039	m_7464039	
-	m	(Lnet/minecraft/unmapped/C_0091050;)V	m_4937135	m_4937135	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073	m_6933073	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		source	
+		p	2		header	
+	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_0091050;	m_5224066	createInstance	
+		p	0		source	
+		p	1		header	
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_2214843;[Z[[F)V	m_8112343	decodeResidue	
+		p	1		vorbis	
+		p	2		source	
+		p	3		mode	
+		p	4		doNotDecodeFlags	
+		p	5		vectors	
+	m	()I	m_7334930	getBegin	
+	m	()I	m_5680415	getEnd	
+	m	()I	m_0954887	getPartitionSize	
+	m	()I	m_8900682	getClassifications	
+	m	()I	m_6433054	getClassBook	
+	m	()[I	m_3528011	getCascade	
+	m	()[[I	m_7464039	getBooks	
+	m	(Lnet/minecraft/unmapped/C_0091050;)V	m_4937135	fill	
+		p	1		clone	
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073	getLook	
+		p	1		source	
+		p	2		key	
 c	net/minecraft/unmapped/C_0190332	net/minecraft/unmapped/C_0190332	
 	m	()V	<init>	<init>	
 	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032	m_3617032	
 		p	0		p_0	
-c	net/minecraft/unmapped/C_0322130	net/minecraft/unmapped/C_0322130	
+c	net/minecraft/unmapped/C_0322130	de/jarnbjo/vorbis/VorbisStream	
 	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447	f_3883447	
-	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360	f_4208360	
-	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945	f_1100945	
-	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100	f_4347100	
-	f	Lnet/minecraft/unmapped/C_8423483;	f_5239443	f_5239443	
-	f	[B	f_8032923	f_8032923	
-	f	I	f_6949479	f_6949479	
-	f	I	f_8986025	f_8986025	
-	f	Ljava/lang/Object;	f_5704116	f_5704116	
-	f	I	f_2640606	f_2640606	
-	f	J	f_6171484	f_6171484	
+	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360	identificationHeader	
+	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945	commentHeader	
+	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100	setupHeader	
+	f	Lnet/minecraft/unmapped/C_8423483;	f_5239443	lastAudioPacket	
+	f	[B	f_8032923	currentPcm	
+	f	I	f_6949479	currentPcmIndex	
+	f	I	f_8986025	currentPcmLimit	
+	f	Ljava/lang/Object;	f_5704116	streamLock	
+	f	I	f_2640606	currentBitRate	
+	f	J	f_6171484	currentGranulePosition	
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/unmapped/C_4958210;)V	<init>	<init>	
-		p	1		p_1	
-	m	([BII)I	m_1114472	m_1114472	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-	m	()Lnet/minecraft/unmapped/C_8423483;	m_0842369	m_0842369	
-c	net/minecraft/unmapped/C_1133045	net/minecraft/unmapped/C_1133045	
-	f	[I	f_5045799	f_5045799	
-	f	[I	f_2332401	f_2332401	
-	f	[I	f_9277376	f_9277376	
-	f	[I	f_5258898	f_5258898	
-	f	[I	f_5326611	f_5326611	
+		p	1		oggStream	
+	m	([BII)I	m_1114472	readPcm	
+		p	1		buffer	
+		p	2		offset	
+		p	3		length	
+	m	()Lnet/minecraft/unmapped/C_8423483;	m_0842369	getNextAudioPacket	
+c	net/minecraft/unmapped/C_1133045	de/jarnbjo/vorbis/Mapping0	
+	f	[I	f_5045799	magnitudes	
+	f	[I	f_2332401	angles	
+	f	[I	f_9277376	mux	
+	f	[I	f_5258898	submapFloors	
+	f	[I	f_5326611	submapResidues	
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
+		p	1		vorbis	
+		p	2		source	
+		p	3		header	
 	m	()[I	m_2841721	m_2841721	
 	m	()[I	m_2863832	m_2863832	
 	m	()[I	m_7804114	m_7804114	
@@ -232,110 +232,110 @@ c	net/minecraft/unmapped/C_1602975	net/minecraft/unmapped/C_1602975
 	m	([SI)I	m_2841446	m_2841446	
 		p	1		p_1	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_1695696	net/minecraft/unmapped/C_1695696	
-	f	I	f_5029809	f_5029809	
-	f	I	f_1898525	f_1898525	
-	f	[Lnet/minecraft/unmapped/C_5664626;	f_0767428	f_0767428	
-	f	Lnet/minecraft/unmapped/C_5664626;	f_2740084	f_2740084	
-	f	[[I	f_5888345	f_5888345	
-	f	I	f_3889701	f_3889701	
-	f	[[I	f_1189336	f_1189336	
+c	net/minecraft/unmapped/C_1695696	de/jarnbjo/vorbis/Look	
+	f	I	f_5029809	parts	
+	f	I	f_1898525	stages	
+	f	[Lnet/minecraft/unmapped/C_5664626;	f_0767428	fullbooks	
+	f	Lnet/minecraft/unmapped/C_5664626;	f_2740084	phrasebook	
+	f	[[I	f_5888345	partbooks	
+	f	I	f_3889701	partvals	
+	f	[[I	f_1189336	decodemap	
 	m	(Lnet/minecraft/unmapped/C_0091050;Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-c	net/minecraft/unmapped/C_1703365	net/minecraft/unmapped/C_1703365	
-	f	I	f_6371034	f_6371034	
-	f	I	f_7347698	f_7347698	
-	f	I	f_1132189	f_1132189	
-	f	I	f_1663762	f_1663762	
-	f	[Lnet/minecraft/unmapped/C_5718344;	f_6370242	f_6370242	
+		p	1		residue	
+		p	2		source	
+		p	3		mode	
+c	net/minecraft/unmapped/C_1703365	de/jarnbjo/vorbis/IdentificationHeader	
+	f	I	f_6371034	channels	
+	f	I	f_7347698	sampleRate	
+	f	I	f_1132189	blockSize0	
+	f	I	f_1663762	blockSize1	
+	f	[Lnet/minecraft/unmapped/C_5718344;	f_6370242	mdct	
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>	<init>	
-		p	1		p_1	
-c	net/minecraft/unmapped/C_1861953	net/minecraft/unmapped/C_1861953	
-	f	Z	f_0834666	f_0834666	
-	f	Z	f_9190175	f_9190175	
-	f	I	f_5891998	f_5891998	
-	f	[I	f_1723045	f_1723045	
-	f	[I	f_6144659	f_6144659	
-	f	I	f_8776241	f_8776241	
-	f	[B	f_8033651	f_8033651	
-	f	[B	f_7534420	f_7534420	
+		p	1		source	
+c	net/minecraft/unmapped/C_1861953	de/jarnbjo/ogg/OggPage	
+	f	Z	f_0834666	continued	
+	f	Z	f_9190175	eos	
+	f	I	f_5891998	streamSerialNumber	
+	f	[I	f_1723045	segmentOffsets	
+	f	[I	f_6144659	segmentLengths	
+	f	I	f_8776241	totalLength	
+	f	[B	f_8033651	segmentTable	
+	f	[B	f_7534420	data	
 	m	()V	<init>	<init>	
 	m	(ZZZJIII[I[II[B[B[B)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
+		p	2		bos	
 		p	3		p_3	
-		p	4		p_4	
+		p	4		absoluteGranulePosition	
 		p	6		p_6	
-		p	7		p_7	
-		p	8		p_8	
+		p	7		pageSequenceNumber	
+		p	8		pageCheckSum	
 		p	9		p_9	
 		p	10		p_10	
 		p	11		p_11	
-		p	12		p_12	
+		p	12		header	
 		p	13		p_13	
 		p	14		p_14	
-	m	(Ljava/io/InputStream;)Lnet/minecraft/unmapped/C_1861953;	m_8807495	m_8807495	
-		p	0		p_0	
-	m	(Ljava/lang/Object;Z)Lnet/minecraft/unmapped/C_1861953;	m_6142753	m_6142753	
-		p	0		p_0	
-		p	1		p_1	
-	m	(Ljava/io/InputStream;[B)V	m_3333673	m_3333673	
-		p	0		p_0	
-		p	1		p_1	
-	m	()I	m_4618783	m_4618783	
+	m	(Ljava/io/InputStream;)Lnet/minecraft/unmapped/C_1861953;	m_8807495	create	
+		p	0		source	
+	m	(Ljava/lang/Object;Z)Lnet/minecraft/unmapped/C_1861953;	m_6142753	create	
+		p	0		source	
+		p	1		skipData	
+	m	(Ljava/io/InputStream;[B)V	m_3333673	readFully	
+		p	0		source	
+		p	1		buffer	
+	m	()I	m_4618783	getTotalLength	
 c	net/minecraft/unmapped/C_1996769	net/minecraft/unmapped/C_1996769	
 	m	([I[II)Z	m_6552350	m_6552350	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
-c	net/minecraft/unmapped/C_2122471	net/minecraft/unmapped/C_2122471	
+c	net/minecraft/unmapped/C_2122471	de/jarnbjo/vorbis/Util	
 	m	()V	<init>	<init>	
-	m	(I)I	m_3224692	m_3224692	
-		p	0		p_0	
-	m	(I)F	m_7418927	m_7418927	
-		p	0		p_0	
-	m	([II)I	m_9852234	m_9852234	
-		p	0		p_0	
-		p	1		p_1	
-	m	([II)I	m_4551640	m_4551640	
-		p	0		p_0	
-		p	1		p_1	
-	m	(IIII[F)V	m_6040209	m_6040209	
-		p	0		p_0	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-c	net/minecraft/unmapped/C_2214843	net/minecraft/unmapped/C_2214843	
-	f	Z	f_3877404	f_3877404	
-	f	I	f_9134511	f_9134511	
-	f	I	f_8453625	f_8453625	
-	f	I	f_5472480	f_5472480	
+	m	(I)I	m_3224692	ilog	
+		p	0		x	
+	m	(I)F	m_7418927	float32unpack	
+		p	0		x	
+	m	([II)I	m_9852234	lowNeighbour	
+		p	0		v	
+		p	1		x	
+	m	([II)I	m_4551640	highNeighbour	
+		p	0		v	
+		p	1		x	
+	m	(IIII[F)V	m_6040209	renderLine	
+		p	0		x0	
+		p	1		y0	
+		p	2		x1	
+		p	3		y1	
+		p	4		v	
+c	net/minecraft/unmapped/C_2214843	de/jarnbjo/vorbis/Mode	
+	f	Z	f_3877404	blockFlag	
+	f	I	f_9134511	windowType	
+	f	I	f_8453625	transformType	
+	f	I	f_5472480	mapping	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-c	net/minecraft/unmapped/C_2480088	net/minecraft/unmapped/C_2480088	
-	f	Ljava/net/URLConnection;	f_9549861	f_9549861	
-	f	Ljava/io/InputStream;	f_1819751	f_1819751	
-	f	I	f_1922040	f_1922040	
-	f	Ljava/util/HashMap;	f_6328291	f_6328291	
-	f	Lnet/minecraft/unmapped/C_1861953;	f_5203731	f_5203731	
+		p	1		source	
+		p	2		header	
+c	net/minecraft/unmapped/C_2480088	de/jarnbjo/ogg/OnDemandUrlStream	
+	f	Ljava/net/URLConnection;	f_9549861	source	
+	f	Ljava/io/InputStream;	f_1819751	sourceStream	
+	f	I	f_1922040	position	
+	f	Ljava/util/HashMap;	f_6328291	logicalStreams	
+	f	Lnet/minecraft/unmapped/C_1861953;	f_5203731	firstPage	
 	m	(Ljava/net/URL;)V	<init>	<init>	
-		p	1		p_1	
-	m	()Lnet/minecraft/unmapped/C_1861953;	m_1806708	m_1806708	
-c	net/minecraft/unmapped/C_3160234	net/minecraft/unmapped/C_3160234	
-	f	[I	f_7127257	f_7127257	
+		p	1		source	
+	m	()Lnet/minecraft/unmapped/C_1861953;	m_1806708	getOggPage	
+c	net/minecraft/unmapped/C_3160234	de/jarnbjo/vorbis/Floor0	
+	f	[I	f_7127257	bookList	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		source	
+		p	2		header	
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155	m_5036155	
 		p	1		p_1	
 		p	2		p_2	
 	m	([F)V	m_5525230	m_5525230	
 		p	1		p_1	
-c	net/minecraft/unmapped/C_4811676	net/minecraft/unmapped/C_4811676	
+c	net/minecraft/unmapped/C_4811676	de/jarnbjo/vorbis/Residue2	
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
 		p	1		p_1	
@@ -347,70 +347,70 @@ c	net/minecraft/unmapped/C_4811676	net/minecraft/unmapped/C_4811676
 		p	4		p_4	
 		p	5		p_5	
 	m	()Ljava/lang/Object;	clone	clone	
-c	net/minecraft/unmapped/C_4958210	net/minecraft/unmapped/C_4958210	
+c	net/minecraft/unmapped/C_4958210	de/jarnbjo/ogg/LogicalOggStreamImpl	
 	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799	f_9154799	
-	f	Ljava/util/ArrayList;	f_2795626	f_2795626	
-	f	I	f_4763122	f_4763122	
-	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523	f_4426523	
-	f	I	f_6597740	f_6597740	
+	f	Ljava/util/ArrayList;	f_2795626	pageNumberMapping	
+	f	I	f_4763122	pageIndex	
+	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523	currentPage	
+	f	I	f_6597740	currentSegmentIndex	
 	m	(Lnet/minecraft/unmapped/C_2480088;)V	<init>	<init>	
-		p	1		p_1	
-	m	()Lnet/minecraft/unmapped/C_1861953;	m_0516762	m_0516762	
-	m	()[B	m_0642862	m_0642862	
-c	net/minecraft/unmapped/C_5664626	net/minecraft/unmapped/C_5664626	
-	f	Lnet/minecraft/unmapped/C_8560236;	f_2040146	f_2040146	
-	f	I	f_4766759	f_4766759	
-	f	I	f_1959361	f_1959361	
-	f	[I	f_2090137	f_2090137	
-	f	[[F	f_7452409	f_7452409	
+		p	1		source	
+	m	()Lnet/minecraft/unmapped/C_1861953;	m_0516762	getNextOggPage	
+	m	()[B	m_0642862	getNextOggPacket	
+c	net/minecraft/unmapped/C_5664626	de/jarnbjo/vorbis/CodeBook	
+	f	Lnet/minecraft/unmapped/C_8560236;	f_2040146	huffmanRoot	
+	f	I	f_4766759	dimensions	
+	f	I	f_1959361	entries	
+	f	[I	f_2090137	entryLengths	
+	f	[[F	f_7452409	valueVector	
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>	<init>	
-		p	1		p_1	
-	m	([I)Z	m_8448942	m_8448942	
-		p	1		p_1	
-c	net/minecraft/unmapped/C_5718344	net/minecraft/unmapped/C_5718344	
+		p	1		source	
+	m	([I)Z	m_8448942	createHuffmanTree	
+		p	1		entryLengths	
+c	net/minecraft/unmapped/C_5718344	de/jarnbjo/vorbis/MdctFloat	
 	f	I	f_3569804	f_3569804	
-	f	I	f_7581426	f_7581426	
-	f	[F	f_4416437	f_4416437	
-	f	[I	f_3575069	f_3575069	
-	f	F	f_1570944	f_1570944	
-	f	F	f_5352698	f_5352698	
-	f	F	f_8288566	f_8288566	
-	f	F	f_7365864	f_7365864	
-	f	[F	f_8917175	f_8917175	
-	f	[F	f_1386816	f_1386816	
+	f	I	f_7581426	log2n	
+	f	[F	f_4416437	trig	
+	f	[I	f_3575069	bitrev	
+	f	F	f_1570944	dtmp1	
+	f	F	f_5352698	dtmp2	
+	f	F	f_8288566	dtmp3	
+	f	F	f_7365864	dtmp4	
+	f	[F	f_8917175	_x	
+	f	[F	f_1386816	_w	
 	m	(I)V	<init>	<init>	
-		p	1		p_1	
-	m	([F[F[I)V	m_4904561	m_4904561	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-c	net/minecraft/unmapped/C_5753145	net/minecraft/unmapped/C_5753145	
-	f	[Lnet/minecraft/unmapped/C_5664626;	f_8744428	f_8744428	
-	f	[Lnet/minecraft/unmapped/C_6848444;	f_1545784	f_1545784	
-	f	[Lnet/minecraft/unmapped/C_0091050;	f_4340403	f_4340403	
-	f	[Lnet/minecraft/unmapped/C_6908252;	f_0234341	f_0234341	
-	f	[Lnet/minecraft/unmapped/C_2214843;	f_1933102	f_1933102	
+		p	1		n	
+	m	([F[F[I)V	m_4904561	imdct	
+		p	1		frq	
+		p	2		window	
+		p	3		pcm	
+c	net/minecraft/unmapped/C_5753145	de/jarnbjo/vorbis/SetupHeader	
+	f	[Lnet/minecraft/unmapped/C_5664626;	f_8744428	codeBooks	
+	f	[Lnet/minecraft/unmapped/C_6848444;	f_1545784	floors	
+	f	[Lnet/minecraft/unmapped/C_0091050;	f_4340403	residues	
+	f	[Lnet/minecraft/unmapped/C_6908252;	f_0234341	mappings	
+	f	[Lnet/minecraft/unmapped/C_2214843;	f_1933102	modes	
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-c	net/minecraft/unmapped/C_5765318	net/minecraft/unmapped/C_5765318	
-	f	[I	f_4591976	f_4591976	
-	f	I	f_4755198	f_4755198	
-	f	I	f_0970456	f_0970456	
-	f	I	f_2129899	f_2129899	
-	f	[I	f_9096800	f_9096800	
-	f	[I	f_2726755	f_2726755	
-	f	[I	f_4057153	f_4057153	
-	f	[[I	f_3838360	f_3838360	
-	f	[I	f_3686218	f_3686218	
-	f	[I	f_3253636	f_3253636	
-	f	[I	f_7690103	f_7690103	
-	f	[I	f_7973024	f_7973024	
-	f	[I	f_1202498	f_1202498	
+		p	1		vorbis	
+		p	2		source	
+c	net/minecraft/unmapped/C_5765318	de/jarnbjo/vorbis/Floor1	
+	f	[I	f_4591976	partitionClassList	
+	f	I	f_4755198	maximumClass	
+	f	I	f_0970456	multiplier	
+	f	I	f_2129899	rangeBits	
+	f	[I	f_9096800	classDimensions	
+	f	[I	f_2726755	classSubclasses	
+	f	[I	f_4057153	classMasterbooks	
+	f	[[I	f_3838360	subclassBooks	
+	f	[I	f_3686218	xList	
+	f	[I	f_3253636	yList	
+	f	[I	f_7690103	lowNeighbours	
+	f	[I	f_7973024	highNeighbours	
+	f	[I	f_1202498	RANGE	
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		source	
+		p	2		header	
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155	m_5036155	
 		p	1		p_1	
 		p	2		p_2	
@@ -446,17 +446,17 @@ c	net/minecraft/unmapped/C_6786807	net/minecraft/unmapped/C_6786807
 		p	2		p_2	
 	m	()F	m_4192289	m_4192289	
 	m	()F	m_2230278	m_2230278	
-c	net/minecraft/unmapped/C_6848444	net/minecraft/unmapped/C_6848444	
-	f	[F	f_3370702	f_3370702	
+c	net/minecraft/unmapped/C_6848444	de/jarnbjo/vorbis/Floor	
+	f	[F	f_3370702	DB_STATIC_TABLE	
 	m	()V	<init>	<init>	
-	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6848444;	m_3831585	m_3831585	
-		p	0		p_0	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155	m_5036155	
-		p	1		p_1	
-		p	2		p_2	
-	m	([F)V	m_5525230	m_5525230	
-		p	1		p_1	
+	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6848444;	m_3831585	createInstance	
+		p	0		source	
+		p	1		header	
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155	decodeFloor	
+		p	1		vorbis	
+		p	2		source	
+	m	([F)V	m_5525230	computeFloor	
+		p	1		vector	
 	m	()V	<clinit>	<clinit>	
 c	net/minecraft/unmapped/C_6857610	net/minecraft/unmapped/C_6857610	
 	f	[S	f_2102733	f_2102733	
@@ -464,19 +464,19 @@ c	net/minecraft/unmapped/C_6857610	net/minecraft/unmapped/C_6857610
 	m	([SF)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_6908252	net/minecraft/unmapped/C_6908252	
+c	net/minecraft/unmapped/C_6908252	de/jarnbjo/vorbis/Mapping	
 	m	()V	<init>	<init>	
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6908252;	m_3513632	m_3513632	
-		p	0		p_0	
-		p	1		p_1	
-		p	2		p_2	
-	m	()[I	m_2841721	m_2841721	
-	m	()[I	m_2863832	m_2863832	
-	m	()[I	m_7804114	m_7804114	
-	m	()[I	m_1912102	m_1912102	
-	m	()[I	m_9055268	m_9055268	
-	m	()I	m_9681215	m_9681215	
-	m	()I	m_6247361	m_6247361	
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6908252;	m_3513632	createInstance	
+		p	0		vorbis	
+		p	1		source	
+		p	2		header	
+	m	()[I	m_2841721	getAngles	
+	m	()[I	m_2863832	getMagnitudes	
+	m	()[I	m_7804114	getMux	
+	m	()[I	m_1912102	getSubmapFloors	
+	m	()[I	m_9055268	getSubmapResidues	
+	m	()I	m_9681215	getCouplingSteps	
+	m	()I	m_6247361	getSubmaps	
 c	net/minecraft/unmapped/C_6975176	net/minecraft/unmapped/C_6975176	
 	m	()F	m_4192289	m_4192289	
 	m	()F	m_2230278	m_2230278	
@@ -552,52 +552,52 @@ c	net/minecraft/unmapped/C_7598507	net/minecraft/unmapped/C_7598507
 	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/lang/String;)Z	m_6859432	m_6859432	
 		p	1		p_1	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_7900390	net/minecraft/unmapped/C_7900390	
-	f	[B	f_8612550	f_8612550	
-	f	B	f_8992957	f_8992957	
-	f	I	f_6974560	f_6974560	
-	f	I	f_0175362	f_0175362	
-	f	I	f_4670471	f_4670471	
+c	net/minecraft/unmapped/C_7900390	de/jarnbjo/util/io/ByteArrayBitInputStream	
+	f	[B	f_8612550	source	
+	f	B	f_8992957	currentByte	
+	f	I	f_6974560	endian	
+	f	I	f_0175362	byteIndex	
+	f	I	f_4670471	bitIndex	
 	m	([B)V	<init>	<init>	
-		p	1		p_1	
+		p	1		source	
 	m	([BI)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
-	m	()Z	m_0530593	m_0530593	
-	m	(I)I	m_6085672	m_6085672	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_8560236;)I	m_1173636	m_1173636	
-		p	1		p_1	
-	m	(I)J	m_1016947	m_1016947	
-		p	1		p_1	
-c	net/minecraft/unmapped/C_8423483	net/minecraft/unmapped/C_8423483	
-	f	I	f_8907271	f_8907271	
-	f	Lnet/minecraft/unmapped/C_2214843;	f_5727714	f_5727714	
-	f	Lnet/minecraft/unmapped/C_6908252;	f_0002876	f_0002876	
-	f	I	f_1372727	f_1372727	
-	f	Z	f_4011038	f_4011038	
-	f	Z	f_1507074	f_1507074	
-	f	Z	f_2033670	f_2033670	
-	f	I	f_4158073	f_4158073	
-	f	I	f_1490965	f_1490965	
-	f	I	f_9464818	f_9464818	
-	f	I	f_8817007	f_8817007	
-	f	I	f_3769840	f_3769840	
-	f	I	f_2972950	f_2972950	
-	f	[F	f_3299597	f_3299597	
-	f	[[F	f_1316142	f_1316142	
-	f	[[I	f_0021803	f_0021803	
-	f	[Lnet/minecraft/unmapped/C_6848444;	f_0180198	f_0180198	
-	f	[Z	f_8030818	f_8030818	
-	f	[[F	f_3369714	f_3369714	
+		p	2		endian	
+	m	()Z	m_0530593	getBit	
+	m	(I)I	m_6085672	getInt	
+		p	1		bits	
+	m	(Lnet/minecraft/unmapped/C_8560236;)I	m_1173636	getInt	
+		p	1		root	
+	m	(I)J	m_1016947	getLong	
+		p	1		bits	
+c	net/minecraft/unmapped/C_8423483	de/jarnbjo/vorbis/AudioPacket	
+	f	I	f_8907271	modeNumber	
+	f	Lnet/minecraft/unmapped/C_2214843;	f_5727714	mode	
+	f	Lnet/minecraft/unmapped/C_6908252;	f_0002876	mapping	
+	f	I	f_1372727	n	
+	f	Z	f_4011038	blockFlag	
+	f	Z	f_1507074	previousWindowFlag	
+	f	Z	f_2033670	nextWindowFlag	
+	f	I	f_4158073	windowCenter	
+	f	I	f_1490965	leftWindowStart	
+	f	I	f_9464818	leftWindowEnd	
+	f	I	f_8817007	leftN	
+	f	I	f_3769840	rightWindowStart	
+	f	I	f_2972950	rightN	
+	f	[F	f_3299597	window	
+	f	[[F	f_1316142	pcm	
+	f	[[I	f_0021803	pcmInt	
+	f	[Lnet/minecraft/unmapped/C_6848444;	f_0180198	channelFloors	
+	f	[Z	f_8030818	noResidues	
+	f	[[F	f_3369714	windows	
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
-	m	()[F	m_4014882	m_4014882	
-	m	()I	m_3048178	m_3048178	
-	m	(Lnet/minecraft/unmapped/C_8423483;[B)V	m_4451826	m_4451826	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		vorbis	
+		p	2		source	
+	m	()[F	m_4014882	getComputedWindow	
+	m	()I	m_3048178	getNumberOfSamples	
+	m	(Lnet/minecraft/unmapped/C_8423483;[B)V	m_4451826	getPcm	
+		p	1		previousPacket	
+		p	2		buffer	
 	m	()V	<clinit>	<clinit>	
 c	net/minecraft/unmapped/C_8534347	net/minecraft/unmapped/C_8534347	
 	f	Z	f_3030770	f_3030770	
@@ -611,28 +611,28 @@ c	net/minecraft/unmapped/C_8534347	net/minecraft/unmapped/C_8534347
 		p	2		p_2	
 	m	()V	run	run	
 	m	()V	<init>	<init>	
-c	net/minecraft/unmapped/C_8560236	net/minecraft/unmapped/C_8560236	
-	f	I	f_7958293	f_7958293	
-	f	Lnet/minecraft/unmapped/C_8560236;	f_9200603	f_9200603	
-	f	Lnet/minecraft/unmapped/C_8560236;	f_6180971	f_6180971	
-	f	Ljava/lang/Integer;	f_1829393	f_1829393	
-	f	Z	f_4791979	f_4791979	
+c	net/minecraft/unmapped/C_8560236	de/jarnbjo/util/io/HuffmanNode	
+	f	I	f_7958293	depth	
+	f	Lnet/minecraft/unmapped/C_8560236;	f_9200603	o0	
+	f	Lnet/minecraft/unmapped/C_8560236;	f_6180971	o1	
+	f	Ljava/lang/Integer;	f_1829393	value	
+	f	Z	f_4791979	full	
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/unmapped/C_8560236;)V	<init>	<init>	
-		p	1		p_1	
+		p	1		parent	
 	m	(Lnet/minecraft/unmapped/C_8560236;I)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	
-	m	()Z	m_0477567	m_0477567	
-	m	(II)Z	m_3923716	m_3923716	
-		p	1		p_1	
+	m	()Z	m_0477567	isFull	
+	m	(II)Z	m_3923716	setNewValue	
+		p	1		depth	
 		p	2		p_2	
-c	net/minecraft/unmapped/C_8903842	net/minecraft/unmapped/C_8903842	
-	f	Ljava/util/HashMap;	f_6719370	f_6719370	
+c	net/minecraft/unmapped/C_8903842	de/jarnbjo/vorbis/CommentHeader	
+	f	Ljava/util/HashMap;	f_6719370	comments	
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>	<init>	
-		p	1		p_1	
-	m	(Lnet/minecraft/unmapped/C_7900390;)Ljava/lang/String;	m_1750090	m_1750090	
-		p	0		p_0	
+		p	1		source	
+	m	(Lnet/minecraft/unmapped/C_7900390;)Ljava/lang/String;	m_1750090	getString	
+		p	0		source	
 c	net/minecraft/unmapped/C_8995754
 	m	()V	m_1055827		m_1055827
 c	net/minecraft/unmapped/C_9158347	net/minecraft/unmapped/C_9158347	
@@ -656,7 +656,7 @@ c	net/minecraft/unmapped/C_9665058
 		p	1		p_1	
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>		<init>
 		p	1			p_1
-c	net/minecraft/unmapped/C_9722514	net/minecraft/unmapped/C_9722514	
+c	net/minecraft/unmapped/C_9722514	de/jarnbjo/vorbis/Residue0	
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	

--- a/mappings/c0.0.22a_05#c0.0.21a.tinydiff
+++ b/mappings/c0.0.22a_05#c0.0.21a.tinydiff
@@ -1,8 +1,8 @@
 tiny	2	0
 c	net/minecraft/unmapped/C_3635204
 	f	Ljava/util/Random;	f_0457756	RANDOM	
-	f	Lnet/minecraft/unmapped/C_7120212;	f_3530839	f_3530839	
-	m	(Lnet/minecraft/unmapped/C_7120212;FF)Lnet/minecraft/unmapped/C_3635204;	m_7659331	m_7659331	
+	f	Lnet/minecraft/unmapped/C_7120212;	f_3530839	sound	
+	m	(Lnet/minecraft/unmapped/C_7120212;FF)Lnet/minecraft/unmapped/C_3635204;	m_7659331	setProperties	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	

--- a/mappings/c0.0.22a_05#c0.0.21a.tinydiff
+++ b/mappings/c0.0.22a_05#c0.0.21a.tinydiff
@@ -119,7 +119,7 @@ c	net/minecraft/unmapped/C_8425960	net/minecraft/client/render/ProgressRenderer
 		p	1		minecraft	
 	m	(Ljava/lang/String;)V	m_3915830	progressStage	
 		p	1		stage	
-	m	(I)V	m_1991224	progressStagePercentage	
+	m	(I)V	m_1991224	progressPercentage	
 		p	1		percentage	
 	m	(Ljava/lang/String;)V	m_1434192	progressStart	
 		p	1		title	

--- a/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
+++ b/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
@@ -35,8 +35,8 @@ c	net/minecraft/unmapped/C_0043270	net/minecraft/client/gui/GuiElement
 		p	2		x2	
 		p	3		y2	
 		p	4		color	
-	m	(Lnet/minecraft/unmapped/C_4766485;Ljava/lang/String;III)V	m_8530248	m_8530248	
-		p	0		p_0	
+	m	(Lnet/minecraft/unmapped/C_4766485;Ljava/lang/String;III)V	m_8530248	drawString	
+		p	0		textRenderer	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
@@ -92,12 +92,12 @@ c	net/minecraft/unmapped/C_2621421
 		p	3		y	
 		p	4		message	
 c	net/minecraft/unmapped/C_3699792
-	f	Ljava/lang/String;	f_5081058	f_5081058	
-	m	(ZII)V	m_1122306	m_1122306	
+	f	Ljava/lang/String;	f_5081058	highlightedPlayer	
+	m	(ZII)V	m_1122306	render	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
-	m	()V	m_1122306		m_1122306
+	m	()V	m_1122306		render
 	m	(IIIIII)V	m_6628097		m_6628097
 		p	0			p_0
 		p	1			p_1
@@ -119,8 +119,8 @@ c	net/minecraft/unmapped/C_3777975	net/minecraft/client/gui/screen/options/Optio
 		p	1		p_1	
 		p	2		p_2	
 c	net/minecraft/unmapped/C_4766485
-	m	(Ljava/lang/String;)Ljava/lang/String;	m_8382370	m_8382370	
-		p	0		p_0	
+	m	(Ljava/lang/String;)Ljava/lang/String;	m_8382370	sanitize	
+		p	0		text	
 c	net/minecraft/unmapped/C_5027199	net/minecraft/client/options/KeyBinding	
 	f	Ljava/lang/String;	f_9295452	name	
 	f	I	f_6140098	keyCode	

--- a/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
+++ b/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
@@ -187,7 +187,7 @@ c	net/minecraft/unmapped/C_5169041
 		p	2		p_2	
 		p	3		p_3	
 c	net/minecraft/unmapped/C_8534347
-	f	Lnet/minecraft/unmapped/C_7688744;	f_2958002	f_2958002	
+	f	Lnet/minecraft/unmapped/C_7688744;	f_2958002	options	
 	f	Z	f_5920001		f_5920001
 	m	(Lnet/minecraft/unmapped/C_7688744;)V	<init>	<init>	
 		p	1		p_1	

--- a/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
+++ b/mappings/c0.0.23a_01#c0.0.22a_05.tinydiff
@@ -1,7 +1,7 @@
 tiny	2	0
 c	net/minecraft/unmapped/C_3724278
 	m	(Lcom/mojang/minecraft/level/Level;III)V	m_0416811
-		p	4		p_4	
+		p	4		z	
 		p	0			p_0
 c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_7688744;	f_6386898	options	

--- a/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
+++ b/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
@@ -168,8 +168,8 @@ c	net/minecraft/client/Minecraft
 	m	()V	m_5678101		handleMouseClick
 c	net/minecraft/unmapped/C_0289174
 	f	Z	f_2994085	flipped	
-	f	Z	f_2797670	f_2797670	
-	f	Z	f_6766296	f_6766296	
+	f	Z	f_2797670	visible	
+	f	Z	f_6766296	invisible	
 	m	(FFFIIIF)V	m_7902911	addBox	
 		p	1		x	
 		p	2		y	
@@ -178,8 +178,8 @@ c	net/minecraft/unmapped/C_0289174
 		p	5		sizeY	
 		p	6		sizeZ	
 		p	7		increase	
-	m	(F)V	m_3169058	m_3169058	
-		p	1		p_1	
+	m	(F)V	m_3169058	compile	
+		p	1		scale	
 	m	(FFFIII)V	m_7902911		addBox
 		p	1			x
 		p	2			y
@@ -190,7 +190,7 @@ c	net/minecraft/unmapped/C_0289174
 c	net/minecraft/unmapped/C_1044273
 	f	Lnet/minecraft/client/Minecraft;	f_5470803	minecraft	
 	f	F	f_6975940	miningProgress	
-	f	[I	f_6069347	f_6069347	
+	f	[I	f_6069347	chunkLists	
 	m	(Lnet/minecraft/client/Minecraft;Lnet/minecraft/unmapped/C_3385278;)V	<init>	<init>	
 		p	1		minecraft	
 		p	2		textureManager	
@@ -221,7 +221,7 @@ c	net/minecraft/unmapped/C_2334550
 		p	2			g
 		p	3			b
 c	net/minecraft/unmapped/C_2454294
-	m	(Lcom/mojang/minecraft/particle/Particle;)V	m_6487687	m_6487687	
+	m	(Lcom/mojang/minecraft/particle/Particle;)V	m_6487687	add	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_2751481	net/minecraft/client/render/ItemInHandRenderer	
 	f	Lnet/minecraft/client/Minecraft;	f_1515651	minecraft	
@@ -233,15 +233,15 @@ c	net/minecraft/unmapped/C_2751481	net/minecraft/client/render/ItemInHandRendere
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		minecraft	
 c	net/minecraft/unmapped/C_3239917	net/minecraft/client/render/model/Model	
-	f	F	f_1553858	f_1553858	
+	f	F	f_1553858	attackAnimationProgress	
 	m	()V	<init>	<init>	
-	m	(FFFFFF)V	m_2584069	m_2584069	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-		p	6		p_6	
+	m	(FFFFFF)V	m_2584069	render	
+		p	1		walkAnimationProgress	
+		p	2		walkAnimationSpeed	
+		p	3		bob	
+		p	4		yaw	
+		p	5		pitch	
+		p	6		scale	
 c	net/minecraft/unmapped/C_3385278
 	f	Ljava/util/HashMap;	f_2107354	textureImages	
 	f	Lnet/minecraft/unmapped/C_7688744;	f_9630201	options	
@@ -260,19 +260,19 @@ c	net/minecraft/unmapped/C_3544790
 c	net/minecraft/unmapped/C_3589148
 	m	([Lnet/minecraft/unmapped/C_9856888;FFFF)V	<init>	<init>	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
+		p	2		u1	
+		p	3		v1	
+		p	4		u2	
+		p	5		v2	
 c	net/minecraft/unmapped/C_3699792
 	f	Ljava/util/Random;	f_2993990	random	
 	f	I	f_8652332	ticks	
-	m	(FZII)V	m_1122306	m_1122306	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-	m	(ZII)V	m_1122306		m_1122306
+	m	(FZII)V	m_1122306	render	
+		p	1		tickDelta	
+		p	2		screenOpen	
+		p	3		mouseX	
+		p	4		mouseY	
+	m	(ZII)V	m_1122306		render
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
@@ -405,7 +405,7 @@ c	com/mojang/minecraft/item/Arrow	com/mojang/minecraft/item/Arrow
 		p	6		p_6	
 		p	7		p_7	
 c	com/mojang/minecraft/item/Item	com/mojang/minecraft/item/Item	
-	f	[Lnet/minecraft/unmapped/C_9882464;	f_5539600	f_5539600	
+	f	[Lnet/minecraft/unmapped/C_9882464;	f_5539600	models	
 	f	F	xd	xd	
 	f	F	yd	yd	
 	f	F	zd	zd	
@@ -686,7 +686,7 @@ c	net/minecraft/unmapped/C_1655833	net/minecraft/client/ClientPlayerInteractionM
 	m	(Lcom/mojang/minecraft/player/Player;I)Z	m_1105336	useItem	
 		p	1		player	
 		p	2		item	
-c	net/minecraft/unmapped/C_3292694	net/minecraft/unmapped/C_3292694	
+c	net/minecraft/unmapped/C_3292694	net/minecraft/client/render/model/entity/SkeletonModel	
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_3464647
 	m	()Ljava/util/List;	m_8518413	getPlayers	
@@ -721,7 +721,7 @@ c	net/minecraft/unmapped/C_5044387	net/minecraft/client/SurvivalInteractionManag
 		p	2		p_2	
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		p_1	
-c	net/minecraft/unmapped/C_7237913	net/minecraft/unmapped/C_7237913	
+c	net/minecraft/unmapped/C_7237913	net/minecraft/client/render/model/entity/ZombieModel	
 	m	()V	<init>	<init>	
 	m	(FFFFFF)V	m_5512614	m_5512614	
 		p	1		p_1	
@@ -731,26 +731,26 @@ c	net/minecraft/unmapped/C_7237913	net/minecraft/unmapped/C_7237913
 		p	5		p_5	
 		p	6		p_6	
 c	net/minecraft/unmapped/C_7898033
-	f	Lnet/minecraft/unmapped/C_0289174;	f_3515609	f_3515609	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_3515609	hat	
 	m	(F)V	<init>	<init>	
-		p	1		p_1	
-	m	(FFFFFF)V	m_5512614	m_5512614	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-		p	6		p_6	
+		p	1		reduction	
+	m	(FFFFFF)V	m_5512614	setupAnimation	
+		p	1		walkAnimationProgress	
+		p	2		walkAnimationSpeed	
+		p	3		bob	
+		p	4		yaw	
+		p	5		pitch	
+		p	6		scale	
 c	net/minecraft/unmapped/C_9665058
 	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_2718498		m_2718498
 		p	1			p_1
-c	net/minecraft/unmapped/C_9823221	net/minecraft/unmapped/C_9823221	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8509466	f_8509466	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8035309	f_8035309	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_2619317	f_2619317	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_5376010	f_5376010	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_1202510	f_1202510	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6231305	f_6231305	
+c	net/minecraft/unmapped/C_9823221	net/minecraft/client/render/model/entity/QuadrupedModel	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8509466	head	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8035309	body	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_2619317	backRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_5376010	backLeftLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_1202510	frontRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6231305	frontLeftLeg	
 	m	(FFFFFF)V	m_2584069	m_2584069	
 		p	1		p_1	
 		p	2		p_2	
@@ -759,11 +759,11 @@ c	net/minecraft/unmapped/C_9823221	net/minecraft/unmapped/C_9823221
 		p	5		p_5	
 		p	6		p_6	
 	m	()V	<init>	<init>	
-c	net/minecraft/unmapped/C_9882464	net/minecraft/unmapped/C_9882464	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0436548	f_0436548	
+c	net/minecraft/unmapped/C_9882464	net/minecraft/client/render/model/BlockModel	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0436548	part	
 	m	(I)V	<init>	<init>	
-		p	1		p_1	
-	m	()V	m_1955164	m_1955164	
+		p	1		sprite	
+	m	()V	m_1955164	render	
 c	com/mojang/minecraft/item/Sign	com/mojang/minecraft/item/Sign	
 	f	Lnet/minecraft/unmapped/C_7841284;	f_2632459	f_2632459	
 	f	F	xd	xd	

--- a/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
+++ b/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
@@ -689,7 +689,7 @@ c	net/minecraft/unmapped/C_1655833	net/minecraft/client/ClientPlayerInteractionM
 c	net/minecraft/unmapped/C_3292694	net/minecraft/unmapped/C_3292694	
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_3464647
-	m	()Ljava/util/List;	m_8518413	m_8518413	
+	m	()Ljava/util/List;	m_8518413	getPlayers	
 c	net/minecraft/unmapped/C_5044387	net/minecraft/client/SurvivalInteractionManager	
 	f	I	f_6685687	targetBlockX	
 	f	I	f_0412535	targetBlockY	

--- a/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
+++ b/mappings/c0.24_st_03#c0.0.23a_01.tinydiff
@@ -17,11 +17,11 @@ c	net/minecraft/unmapped/C_0974371
 	m	()I	m_3282602	m_3282602	
 c	net/minecraft/unmapped/C_1124552
 	m	()Z	m_1538589	m_1538589	
-	m	(Lnet/minecraft/unmapped/C_2334550;FFF)V	m_3078875	m_3078875	
+	m	(Lnet/minecraft/unmapped/C_2334550;FFF)V	m_3078875	render	
 		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
+		p	2		x	
+		p	3		y	
+		p	4		z	
 	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_3016343	m_3016343	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_3635204
@@ -32,11 +32,11 @@ c	net/minecraft/unmapped/C_3635204
 	f	Z	f_8002233	f_8002233	
 	m	()Z	m_1538589	isCube	
 	m	()I	m_1396444	getMiningTime	
-	m	(Lnet/minecraft/unmapped/C_7120212;FFF)Lnet/minecraft/unmapped/C_3635204;	m_7659331	m_7659331	
-		p	1		p_1	
+	m	(Lnet/minecraft/unmapped/C_7120212;FFF)Lnet/minecraft/unmapped/C_3635204;	m_7659331	setProperties	
+		p	1		sound	
 		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
+		p	3		weight	
+		p	4		hardness	
 	m	(Lnet/minecraft/unmapped/C_2334550;IIIII)V	m_3802329	m_3802329	
 		p	1		p_1	
 		p	2		p_2	
@@ -44,20 +44,20 @@ c	net/minecraft/unmapped/C_3635204
 		p	4		p_4	
 		p	5		p_5	
 		p	6		p_6	
-	m	(Lcom/mojang/minecraft/level/Level;IIIILnet/minecraft/unmapped/C_2454294;)V	m_9622802	m_9622802	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
-		p	6		p_6	
+	m	(Lcom/mojang/minecraft/level/Level;IIIILnet/minecraft/unmapped/C_2454294;)V	m_9622802	addDamageParticles	
+		p	1		world	
+		p	2		x	
+		p	3		y	
+		p	4		z	
+		p	5		face	
+		p	6		particleManager	
 	m	()I	m_6534436	getBaseDropCount	
 	m	(Lcom/mojang/minecraft/level/Level;III)V	m_6201869	dropItems	
 		p	1		level	
 		p	2		x	
 		p	3		y	
 		p	4		z	
-	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_3016343	m_3016343	
+	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_3016343	render	
 		p	1		p_1	
 	m	(Lnet/minecraft/unmapped/C_2334550;IIIII)V	m_7094367	m_7094367	
 		p	1		p_1	
@@ -73,7 +73,7 @@ c	net/minecraft/unmapped/C_3635204
 		p	3		p_3	
 		p	4		p_4	
 		p	5		p_5	
-	m	(Lnet/minecraft/unmapped/C_7120212;FF)Lnet/minecraft/unmapped/C_3635204;	m_7659331		m_7659331
+	m	(Lnet/minecraft/unmapped/C_7120212;FF)Lnet/minecraft/unmapped/C_3635204;	m_7659331		setProperties
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3

--- a/mappings/c0.25_05_st#c0.24_st_03.tinydiff
+++ b/mappings/c0.25_05_st#c0.24_st_03.tinydiff
@@ -9,8 +9,8 @@ c	net/minecraft/client/Minecraft$3076803	3076803
 		p	1		p_1	
 	m	()V	run	run	
 c	net/minecraft/unmapped/C_3385278
-	m	(Ljava/awt/image/BufferedImage;)I	m_6444891	m_6444891	
-		p	1		p_1	
+	m	(Ljava/awt/image/BufferedImage;)I	m_6444891	load	
+		p	1		image	
 c	com/mojang/minecraft/Entity
 	f	Lcom/mojang/minecraft/level/BlockMap;	blockMap	blockMap	
 	f	Lnet/minecraft/unmapped/C_5343712;	blockMap		blockMap
@@ -303,16 +303,16 @@ c	com/mojang/minecraft/player/Player$0060214		0060214
 		p	1			p_1
 		p	2			p_2
 	m	()V	m_0827508		m_0827508
-c	net/minecraft/unmapped/C_6760097	net/minecraft/unmapped/C_6760097	
-	f	Lnet/minecraft/unmapped/C_7898033;	f_4538254	f_4538254	
-	f	Lnet/minecraft/unmapped/C_7898033;	f_0631287	f_0631287	
-	f	Lnet/minecraft/unmapped/C_4590573;	f_5988746	f_5988746	
-	f	Lnet/minecraft/unmapped/C_3292694;	f_2011282	f_2011282	
-	f	Lnet/minecraft/unmapped/C_7237913;	f_7875334	f_7875334	
-	f	Lnet/minecraft/unmapped/C_9823221;	f_5872396	f_5872396	
+c	net/minecraft/unmapped/C_6760097	net/minecraft/client/render/model/ModelCache	
+	f	Lnet/minecraft/unmapped/C_7898033;	f_4538254	humanoid	
+	f	Lnet/minecraft/unmapped/C_7898033;	f_0631287	humanoidArmor	
+	f	Lnet/minecraft/unmapped/C_4590573;	f_5988746	creeper	
+	f	Lnet/minecraft/unmapped/C_3292694;	f_2011282	skeleton	
+	f	Lnet/minecraft/unmapped/C_7237913;	f_7875334	zombie	
+	f	Lnet/minecraft/unmapped/C_9823221;	f_5872396	pig	
 	m	()V	<init>	<init>	
-	m	(Ljava/lang/String;)Lnet/minecraft/unmapped/C_3239917;	m_3976542	m_3976542	
-		p	1		p_1	
+	m	(Ljava/lang/String;)Lnet/minecraft/unmapped/C_3239917;	m_3976542	get	
+		p	1		id	
 c	com/mojang/minecraft/item/Sign
 	f	J	serialVersionUID	serialVersionUID	
 	f	Lnet/minecraft/unmapped/C_4766485;	font		font

--- a/mappings/c0.27_st#c0.25_05_st.tinydiff
+++ b/mappings/c0.27_st#c0.25_05_st.tinydiff
@@ -24,7 +24,7 @@ c	net/minecraft/unmapped/C_3635204
 	f	Lnet/minecraft/unmapped/C_3635204;	f_8596290	BRICKS	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_2379017	BOOKSHELF	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_4783636	MOSSY_COBBLESTONE	
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1899131	f_1899131	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1899131	IRON_BLOCK	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_3811921	TNT	
 	f	Z	f_7253534	f_7253534	
 	m	(Lnet/minecraft/unmapped/C_0336319;)Z	m_0588089	containsX	

--- a/mappings/c0.27_st#c0.25_05_st.tinydiff
+++ b/mappings/c0.27_st#c0.25_05_st.tinydiff
@@ -245,7 +245,7 @@ c	com/mojang/minecraft/player/Player$1
 c	net/minecraft/unmapped/C_1655833
 	m	(Lcom/mojang/minecraft/player/Player;)V	m_2848601	initPlayer	
 		p	1		player	
-c	net/minecraft/unmapped/C_2964760	net/minecraft/unmapped/C_2964760	
+c	net/minecraft/unmapped/C_2964760	net/minecraft/block/StoneBlock	
 	m	(II)V	<init>	<init>	
 		p	1		p_1	
 		p	2		p_2	

--- a/mappings/c0.27_st#c0.25_05_st.tinydiff
+++ b/mappings/c0.27_st#c0.25_05_st.tinydiff
@@ -104,7 +104,7 @@ c	net/minecraft/unmapped/C_2454294
 	f	[Ljava/util/List;	f_7065352	particles	
 	f	Ljava/util/List;	f_5543693		particles
 c	net/minecraft/unmapped/C_4766485
-	f	Lnet/minecraft/unmapped/C_7688744;	f_9105384	f_9105384	
+	f	Lnet/minecraft/unmapped/C_7688744;	f_9105384	options	
 	m	(Lnet/minecraft/unmapped/C_7688744;Ljava/lang/String;Lnet/minecraft/unmapped/C_3385278;)V	<init>	<init>	
 		p	1		options	
 		p	2		fontPath	
@@ -250,18 +250,18 @@ c	net/minecraft/unmapped/C_2964760	net/minecraft/unmapped/C_2964760
 		p	1		p_1	
 		p	2		p_2	
 	m	()I	m_3282602	m_3282602	
-c	net/minecraft/unmapped/C_4304615	net/minecraft/unmapped/C_4304615	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8977126	f_8977126	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9247043	f_9247043	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8893709	f_8893709	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9464243	f_9464243	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0852856	f_0852856	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0218467	f_0218467	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0996130	f_0996130	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6651414	f_6651414	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9789835	f_9789835	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_7831538	f_7831538	
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6302099	f_6302099	
+c	net/minecraft/unmapped/C_4304615	net/minecraft/client/render/model/entity/SpiderEntity	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8977126	head	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9247043	neck	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8893709	body	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9464243	backRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0852856	backLeftLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0218467	backMiddleRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0996130	backMiddleLeftLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6651414	frontMiddleRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9789835	frontMiddleLeftLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_7831538	frontRightLeg	
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6302099	frontLeftLeg	
 	m	()V	<init>	<init>	
 	m	(FFFFFF)V	m_2584069	m_2584069	
 		p	1		p_1	
@@ -274,7 +274,7 @@ c	net/minecraft/unmapped/C_5044387
 	m	(Lcom/mojang/minecraft/player/Player;)V	m_2848601	m_2848601	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_6760097
-	f	Lnet/minecraft/unmapped/C_4304615;	f_9250233	f_9250233	
+	f	Lnet/minecraft/unmapped/C_4304615;	f_9250233	spider	
 c	com/mojang/minecraft/item/PrimedTnt	com/mojang/minecraft/item/PrimedTnt	
 	f	J	serialVersionUID	serialVersionUID	
 	f	F	xd	xd	

--- a/mappings/c0.28_01#c0.27_st.tinydiff
+++ b/mappings/c0.28_01#c0.27_st.tinydiff
@@ -183,9 +183,9 @@ c	net/minecraft/unmapped/C_1044273
 		p	2			p_2
 		p	3			p_3
 c	net/minecraft/unmapped/C_2454294
-	m	(Lcom/mojang/minecraft/Entity;)V	m_6487687	m_6487687	
-		p	1		p_1	
-	m	(Lcom/mojang/minecraft/particle/Particle;)V	m_6487687		m_6487687
+	m	(Lcom/mojang/minecraft/Entity;)V	m_6487687	add	
+		p	1		particle	
+	m	(Lcom/mojang/minecraft/particle/Particle;)V	m_6487687		add
 		p	1			p_1
 	m	(Lcom/mojang/minecraft/player/Player;F)V	m_5775841		render
 		p	1			p_1
@@ -198,8 +198,8 @@ c	net/minecraft/unmapped/C_5283200
 	f	Z	f_7818563		dirty
 	m	()V	m_0330444	compile	
 	m	([III)I	m_8783499	getGlList	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		glLists	
+		p	2		offset	
 		p	3		layer	
 	m	(Lnet/minecraft/unmapped/C_0669153;)V	m_5092852	cull	
 		p	1		frustum	
@@ -223,9 +223,9 @@ c	net/minecraft/unmapped/C_7542541	net/minecraft/client/gui/screen/inventory/men
 	m	(II)V	m_3426670	m_3426670	
 		p	1		p_1	
 		p	2		p_2	
-	m	(II)I	m_8154932	m_8154932	
-		p	1		p_1	
-		p	2		p_2	
+	m	(II)I	m_8154932	findClosestSlot	
+		p	1		mouseX	
+		p	2		mouseY	
 c	net/minecraft/unmapped/C_7564962	net/minecraft/client/CreativeInteractionManager	
 	m	()Z	m_4103218	m_4103218	
 	m	()V	m_1894352	m_1894352	
@@ -240,7 +240,7 @@ c	net/minecraft/unmapped/C_7688744
 c	net/minecraft/unmapped/C_0388903
 	m	()V	m_2060594	m_2060594	
 c	net/minecraft/unmapped/C_5540851
-	f	Z	f_9717986	f_9717986	
+	f	Z	f_9717986	selecting	
 c	net/minecraft/unmapped/C_1051907	net/minecraft/world/NaturalSpawner	
 	f	Lcom/mojang/minecraft/level/Level;	f_5139716	world	
 	m	(Lcom/mojang/minecraft/level/Level;)V	<init>	<init>	
@@ -396,7 +396,7 @@ c	com/mojang/minecraft/player/Player
 		p	1		p_1	
 		p	2		p_2	
 	m	()Z	isCreativeModeAllowed	isCreativeModeAllowed	
-c	net/minecraft/unmapped/C_1168442	net/minecraft/unmapped/C_1168442	
+c	net/minecraft/unmapped/C_1168442	net/minecraft/client/render/model/entity/SheepFurModel	
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_1655833
 	m	(Lcom/mojang/minecraft/level/Level;)V	m_9151419	initLevel	
@@ -410,7 +410,7 @@ c	net/minecraft/unmapped/C_1655833
 		p	1		player	
 c	net/minecraft/unmapped/C_2964760
 	m	()I	m_3282602		m_3282602
-c	net/minecraft/unmapped/C_4632560	net/minecraft/unmapped/C_4632560	
+c	net/minecraft/unmapped/C_4632560	net/minecraft/client/render/model/entity/SheepModel	
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_5044387
 	f	Lnet/minecraft/unmapped/C_1051907;	f_8072963	naturalSpawner	
@@ -422,9 +422,9 @@ c	net/minecraft/unmapped/C_5044387
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>		<init>
 		p	1			p_1
 c	net/minecraft/unmapped/C_6760097
-	f	Lnet/minecraft/unmapped/C_9823221;	f_6381842	f_6381842	
-	f	Lnet/minecraft/unmapped/C_1168442;	f_7721878	f_7721878	
-c	net/minecraft/unmapped/C_7138722	net/minecraft/unmapped/C_7138722	
+	f	Lnet/minecraft/unmapped/C_9823221;	f_6381842	sheep	
+	f	Lnet/minecraft/unmapped/C_1168442;	f_7721878	sheepFur	
+c	net/minecraft/unmapped/C_7138722	net/minecraft/client/render/model/entity/PigModel	
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_8100347	net/minecraft/unmapped/C_8100347	
 	f	Ljava/util/Set;	f_9798909	f_9798909	
@@ -433,8 +433,8 @@ c	net/minecraft/unmapped/C_8100347	net/minecraft/unmapped/C_8100347
 	m	()Ljava/io/ObjectStreamClass;	readClassDescriptor	readClassDescriptor	
 c	net/minecraft/unmapped/C_9823221
 	m	(IF)V	<init>	<init>	
-		p	1		p_1	
-		p	2		p_2	
+		p	1		pivotPoint	
+		p	2		reduction	
 	m	()V	<init>		<init>
 c	com/mojang/minecraft/item/PrimedTnt		com/mojang/minecraft/item/PrimedTnt
 	f	J	serialVersionUID		serialVersionUID

--- a/mappings/c0.28_01#c0.27_st.tinydiff
+++ b/mappings/c0.28_01#c0.27_st.tinydiff
@@ -36,7 +36,7 @@ c	net/minecraft/unmapped/C_1124552
 		p	5			p_5
 		p	6			p_6
 c	net/minecraft/unmapped/C_3635204
-	f	Lnet/minecraft/unmapped/C_3635204;	f_9027845	f_9027845	
+	f	Lnet/minecraft/unmapped/C_3635204;	f_9027845	OBSIDIAN	
 	f	Z	f_8002233		f_8002233
 	m	()I	m_5117733	getRenderLayer	
 		c	Returns this block's render layer. The possible values are as follows:\n<br>0: solid\n<br>1: mipped cutout\n<br>2: cutout\n<br>3: translucent	
@@ -48,11 +48,11 @@ c	net/minecraft/unmapped/C_3635204
 		p	3		y	
 		p	4		z	
 		p	5		face	
-	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2334550;)Z	m_7740877	m_7740877	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
+	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2334550;)Z	m_7740877	render	
+		p	1		world	
+		p	2		x	
+		p	3		y	
+		p	4		z	
 		p	5		p_5	
 	m	(F)V	m_5317075	dropItems	
 		p	1		p_1	

--- a/mappings/c0.28_01#c0.27_st.tinydiff
+++ b/mappings/c0.28_01#c0.27_st.tinydiff
@@ -426,8 +426,8 @@ c	net/minecraft/unmapped/C_6760097
 	f	Lnet/minecraft/unmapped/C_1168442;	f_7721878	sheepFur	
 c	net/minecraft/unmapped/C_7138722	net/minecraft/client/render/model/entity/PigModel	
 	m	()V	<init>	<init>	
-c	net/minecraft/unmapped/C_8100347	net/minecraft/unmapped/C_8100347	
-	f	Ljava/util/Set;	f_9798909	f_9798909	
+c	net/minecraft/unmapped/C_8100347	net/minecraft/world/storage/EntityObjectInputStream	
+	f	Ljava/util/Set;	f_9798909	types	
 	m	(Ljava/io/InputStream;)V	<init>	<init>	
 		p	1		p_1	
 	m	()Ljava/io/ObjectStreamClass;	readClassDescriptor	readClassDescriptor	

--- a/mappings/c0.29#c0.28_01.tinydiff
+++ b/mappings/c0.29#c0.28_01.tinydiff
@@ -2,4 +2,4 @@ tiny	2	0
 c	com/mojang/minecraft/level/Level
 	f	Z	growTrees	growTrees	
 c	net/minecraft/unmapped/C_3600653
-	f	Lnet/minecraft/unmapped/C_3600653;	f_4805617	f_4805617	
+	f	Lnet/minecraft/unmapped/C_3600653;	f_4805617	UPDATE_USER_TYPE	

--- a/mappings/c0.29_01#c0.29.tinydiff
+++ b/mappings/c0.29_01#c0.29.tinydiff
@@ -3,7 +3,7 @@ c	net/minecraft/unmapped/C_0336319
 	m	(Lnet/minecraft/unmapped/C_0336319;)F	m_8920503	squaredDistanceTo	
 		p	1		vec	
 c	net/minecraft/unmapped/C_4824661
-	f	Lcom/mojang/minecraft/Entity;	f_6384737	f_6384737	
+	f	Lcom/mojang/minecraft/Entity;	f_6384737	camera	
 c	com/mojang/minecraft/Entity
 	f	Z	hovered	hovered	
 	m	(Lnet/minecraft/unmapped/C_3385278;F)V	renderHover	renderHover	

--- a/mappings/c0.30-c-renew#c0.30-c.tinydiff
+++ b/mappings/c0.30-c-renew#c0.30-c.tinydiff
@@ -1,1 +1,3 @@
 tiny	2	0
+c	net/minecraft/unmapped/C_0351020	net/minecraft/block/StoneBlock	net/minecraft/block/DirtBlock
+c	net/minecraft/unmapped/C_2964760	net/minecraft/unmapped/C_2964760	net/minecraft/block/StoneBlock

--- a/mappings/c0.30-s#c0.29_02.tinydiff
+++ b/mappings/c0.30-s#c0.29_02.tinydiff
@@ -6,13 +6,13 @@ c	net/minecraft/unmapped/C_0823907
 c	net/minecraft/unmapped/C_0974371
 	m	()I	m_1206777	m_1206777	
 c	net/minecraft/unmapped/C_3635204
-	m	()I	m_1206777	m_1206777	
+	m	()I	m_1206777	getDropItem	
 	m	(Lcom/mojang/minecraft/level/Level;IIIF)V	m_5317075	dropItems	
-		p	1		p_1	
-		p	2		p_2	
-		p	3		p_3	
-		p	4		p_4	
-		p	5		p_5	
+		p	1		world	
+		p	2		x	
+		p	3		y	
+		p	4		z	
+		p	5		chance	
 	m	(Lcom/mojang/minecraft/level/Level;III)V	m_5709385	onBroken	
 		p	1		world	
 		p	2		x	

--- a/mappings/c0.30-s#c0.29_02.tinydiff
+++ b/mappings/c0.30-s#c0.29_02.tinydiff
@@ -40,9 +40,9 @@ c	net/minecraft/unmapped/C_7318150
 c	net/minecraft/unmapped/C_9331929
 	m	()I	m_1206777	m_1206777	
 c	net/minecraft/client/Minecraft
-	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645	f_0976645	
+	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645	applet	
 c	net/minecraft/unmapped/C_3172064
-	f	Z	f_0965783	f_0965783	
+	f	Z	f_0965783	paid	
 c	net/minecraft/unmapped/C_7564962
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>		<init>
 		p	1			p_1
@@ -55,10 +55,10 @@ c	net/minecraft/unmapped/C_0388903
 	m	(Ljava/io/File;)V	m_2685840	m_2685840	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_5540851
-	f	Ljavax/swing/JFileChooser;	f_8271264	f_8271264	
-	f	Z	f_4651522	f_4651522	
-	f	Ljava/io/File;	f_8809966	f_8809966	
-	m	(Ljava/io/File;)V	m_2685840	m_2685840	
+	f	Ljavax/swing/JFileChooser;	f_8271264	fileChooser	
+	f	Z	f_4651522	shouldSave	
+	f	Ljava/io/File;	f_8809966	selectedFile	
+	m	(Ljava/io/File;)V	m_2685840	handleSelection	
 		p	1		p_1	
 	m	()V	m_5056964	m_5056964	
 	m	()V	m_7135145	m_7135145	
@@ -111,8 +111,8 @@ c	net/minecraft/unmapped/C_5044387
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		p_1	
 c	net/minecraft/unmapped/C_9665058
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/File;)Z	m_7243453	m_7243453	
-		p	1		p_1	
-		p	2		p_2	
-	m	(Ljava/io/File;)Lcom/mojang/minecraft/level/Level;	m_2273715	m_2273715	
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/File;)Z	m_7243453	save	
+		p	1		world	
+		p	2		file	
+	m	(Ljava/io/File;)Lcom/mojang/minecraft/level/Level;	m_2273715	load	
 		p	1		p_1	

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -1062,15 +1062,15 @@ c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_1655833;	f_7165322		interactionManager
 	f	Lcom/mojang/minecraft/level/Level;	f_5337597		world
 	f	Lcom/mojang/minecraft/player/Player;	f_5473933		player
-	f	Lnet/minecraft/unmapped/C_9665058;	f_1737492		f_1737492
+	f	Lnet/minecraft/unmapped/C_9665058;	f_1737492		worldStorage
 	f	Lnet/minecraft/unmapped/C_7598507;	f_2497216		f_2497216
-	f	Ljava/lang/String;	f_6753290		f_6753290
-	f	I	f_5242116		f_5242116
-	f	Z	f_4909729		f_4909729
+	f	Ljava/lang/String;	f_6753290		loadmapUser
+	f	I	f_5242116		loadmapId
+	f	Z	f_4909729		skipGameRender
 	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748		networkHandler
 	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934		f_1501934
-	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645		f_0976645
-	f	I	f_0132506		f_0132506
+	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645		applet
+	f	I	f_0132506		startupServerPort
 	m	(Lnet/minecraft/unmapped/C_3906126;)V	m_6427459	setWorld	
 		p	1		world	
 	m	(Ljava/awt/Canvas;IIZ)V	<init>	<init>	
@@ -1084,12 +1084,12 @@ c	net/minecraft/client/Minecraft
 		p	3			p_3
 		p	4			p_4
 		p	5			p_5
-	m	()Z	m_7044458		m_7044458
-	m	(Ljava/lang/String;I)Z	m_8752834		m_8752834
-		p	1			p_1
-		p	2			p_2
+	m	()Z	m_7044458		isRemote
+	m	(Ljava/lang/String;I)Z	m_8752834		loadWorld
+		p	1			username
+		p	2			slot
 	m	(Lcom/mojang/minecraft/level/Level;)V	m_6427459		setWorld
-		p	1			p_1
+		p	1			world
 c	net/minecraft/client/Minecraft$7968884
 	m	()V	<init>	<init>	
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>		<init>
@@ -1116,8 +1116,8 @@ c	net/minecraft/client/MinecraftApplet$5746331	5746331
 	m	()V	addNotify	addNotify	
 	m	()V	removeNotify	removeNotify	
 c	net/minecraft/unmapped/C_0043270
-	m	(Lnet/minecraft/unmapped/C_4766485;Ljava/lang/String;III)V	m_8530248		m_8530248
-		p	0			p_0
+	m	(Lnet/minecraft/unmapped/C_4766485;Ljava/lang/String;III)V	m_8530248		drawString
+		p	0			textRenderer
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
@@ -1137,16 +1137,16 @@ c	net/minecraft/unmapped/C_0289174
 	f	F	f_0768495		rotationZ
 	f	Z	f_7948508		compiled
 	f	I	f_3894400		glList
-	f	Z	f_2797670		f_2797670
-	f	Z	f_6766296		f_6766296
+	f	Z	f_2797670		visible
+	f	Z	f_6766296		invisible
 	m	(FFF)V	m_4478491		setPos
 		p	1			x
 		p	2			y
 		p	3			z
 	m	(F)V	m_8346450		render
-		p	1			p_1
-	m	(F)V	m_3169058		m_3169058
-		p	1			p_1
+		p	1			scale
+	m	(F)V	m_3169058		compile
+		p	1			scale
 c	net/minecraft/unmapped/C_0384965	net/minecraft/client/render/texture/WaterSideSprite	
 	f	[F	f_1247368	current	
 	f	[F	f_8657575	next	
@@ -1156,7 +1156,7 @@ c	net/minecraft/unmapped/C_0384965	net/minecraft/client/render/texture/WaterSide
 	m	()V	<init>	<init>	
 	m	()V	m_4399705	m_4399705	
 c	net/minecraft/unmapped/C_0786431
-	m	()V	m_0614547		m_0614547
+	m	()V	m_0614547		handleInputs
 c	net/minecraft/unmapped/C_1044273
 	f	Lnet/minecraft/unmapped/C_3906126;	f_4415583	world	
 	f	Lnet/minecraft/unmapped/C_3466301;	f_9902985	blockRenderer	
@@ -1167,7 +1167,7 @@ c	net/minecraft/unmapped/C_1044273
 		p	2		layer	
 	m	(Lcom/mojang/minecraft/player/Player;I)I	m_8682700		render
 		p	1			p_1
-		p	2			p_2
+		p	2			layer
 c	net/minecraft/unmapped/C_2334550
 	m	()V	m_9321627	begin	
 		c	Start with default draw mode {@link org.lwjgl.opengl.GL11#GL_QUADS GL_QUADS}	
@@ -1191,9 +1191,9 @@ c	net/minecraft/unmapped/C_2454294
 	m	(Lcom/mojang/minecraft/level/Level;Lnet/minecraft/unmapped/C_3385278;)V	<init>		<init>
 		p	1			world
 		p	2			textureManager
-	m	(Lcom/mojang/minecraft/Entity;)V	m_6487687		m_6487687
-		p	1			p_1
-	m	()V	m_4221773		m_4221773
+	m	(Lcom/mojang/minecraft/Entity;)V	m_6487687		add
+		p	1			particle
+	m	()V	m_4221773		tick
 c	net/minecraft/unmapped/C_2621421
 	m	(IIIILjava/lang/String;)V	<init>	<init>	
 		p	1		p_1	
@@ -1206,7 +1206,7 @@ c	net/minecraft/unmapped/C_2621421
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
-		p	5			p_5
+		p	5			height
 		p	6			p_6
 c	net/minecraft/unmapped/C_2751481
 	f	Lnet/minecraft/unmapped/C_3466301;	f_9447755	blockRenderer	
@@ -1218,23 +1218,23 @@ c	net/minecraft/unmapped/C_2813741
 	m	(Lcom/mojang/minecraft/player/Player;)V	<init>		<init>
 		p	1			p_1
 c	net/minecraft/unmapped/C_3172064
-	f	Ljava/lang/String;	f_1305529		f_1305529
-	f	Ljava/lang/String;	f_2577321		f_2577321
-	f	Z	f_0965783		f_0965783
+	f	Ljava/lang/String;	f_1305529		id
+	f	Ljava/lang/String;	f_2577321		password
+	f	Z	f_0965783		paid
 	m	(Ljava/lang/String;)V	<init>	<init>	
 		p	1		p_1	
 	m	(Ljava/lang/String;Ljava/lang/String;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
 c	net/minecraft/unmapped/C_3239917
-	f	F	f_1553858		f_1553858
-	m	(FFFFFF)V	m_2584069		m_2584069
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-		p	6			p_6
+	f	F	f_1553858		attackAnimationProgress
+	m	(FFFFFF)V	m_2584069		render
+		p	1			walkAnimationProgress
+		p	2			walkAnimationSpeed
+		p	3			bob
+		p	4			yaw
+		p	5			pitch
+		p	6			scale
 c	net/minecraft/unmapped/C_3271339	net/minecraft/client/SurvivalInteractionManager	
 	f	I	f_9195163	targetBlockX	
 	f	I	f_5397190	targetBlockY	
@@ -1271,8 +1271,8 @@ c	net/minecraft/unmapped/C_3271339	net/minecraft/client/SurvivalInteractionManag
 		p	2		p_2	
 c	net/minecraft/unmapped/C_3385278
 	f	Z	f_9265078	blur	
-	m	(Ljava/awt/image/BufferedImage;)I	m_6444891		m_6444891
-		p	1			p_1
+	m	(Ljava/awt/image/BufferedImage;)I	m_6444891		load
+		p	1			image
 c	net/minecraft/unmapped/C_3466301	net/minecraft/client/render/block/BlockRenderer	
 	f	I	f_2997631	forcedSprite	
 	f	Z	f_3103336	renderFaceAlways	
@@ -1341,22 +1341,22 @@ c	net/minecraft/unmapped/C_3466301	net/minecraft/client/render/block/BlockRender
 c	net/minecraft/unmapped/C_3589148
 	m	([Lnet/minecraft/unmapped/C_9856888;FFFF)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
+		p	2			u1
+		p	3			v1
+		p	4			u2
+		p	5			v2
 c	net/minecraft/unmapped/C_3699792
 	f	Lnet/minecraft/unmapped/C_3466301;	f_8774221	ITEM_RENDERER	
-	f	Ljava/lang/String;	f_5081058		f_5081058
+	f	Ljava/lang/String;	f_5081058		highlightedPlayer
 	m	(F)V	m_0276783	render	
 		p	1		p_1	
-	m	(FZII)V	m_1122306		m_1122306
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-	m	(Ljava/lang/String;)V	m_6992985		m_6992985
-		p	1			p_1
+	m	(FZII)V	m_1122306		render
+		p	1			tickDelta
+		p	2			screenOpen
+		p	3			mouseX
+		p	4			mouseY
+	m	(Ljava/lang/String;)V	m_6992985		addMessage
+		p	1			content
 c	net/minecraft/unmapped/C_3794155	net/minecraft/client/entity/particle/BlockParticle	
 	m	()I	m_5603541	m_5603541	
 	m	(Lnet/minecraft/unmapped/C_2334550;FFFFFF)V	m_7521183	m_7521183	
@@ -1453,18 +1453,18 @@ c	net/minecraft/unmapped/C_4766485
 		p	2		x	
 		p	3		y	
 		p	4		color	
-	m	(Ljava/lang/String;III)V	m_4507504		m_4507504
+	m	(Ljava/lang/String;III)V	m_4507504		drawWithShadow
+		p	1			text
+		p	2			p_2
+		p	3			p_3
+		p	4			color
+	m	(Ljava/lang/String;III)V	m_5762160		draw
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
-	m	(Ljava/lang/String;III)V	m_5762160		m_5762160
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-	m	(Ljava/lang/String;)Ljava/lang/String;	m_8382370		m_8382370
-		p	0			p_0
+	m	(Ljava/lang/String;)Ljava/lang/String;	m_8382370		sanitize
+		p	0			text
 c	net/minecraft/unmapped/C_4824661
 	f	F	f_5637768	renderDistance	
 	f	Lnet/minecraft/unmapped/C_6385858;	f_2468143	targetEntity	
@@ -1472,23 +1472,23 @@ c	net/minecraft/unmapped/C_4824661
 	f	F	f_1498815	fogGreen	
 	f	F	f_4930127	fogBlue	
 	f	F	f_4122154	f_4122154	
-	f	F	f_9070619		f_9070619
-	f	F	f_3370476		f_3370476
-	f	Lcom/mojang/minecraft/Entity;	f_6384737		f_6384737
-	f	F	f_9901150		f_9901150
-	f	F	f_6447311		f_6447311
-	f	F	f_3735549		f_3735549
+	f	F	f_9070619		fogBrightness
+	f	F	f_3370476		renderDistance
+	f	Lcom/mojang/minecraft/Entity;	f_6384737		camera
+	f	F	f_9901150		fogRed
+	f	F	f_6447311		fogGreen
+	f	F	f_3735549		fogBlue
 	m	(F)V	m_2927621	renderWorld	
 		p	1		tickDelta	
 	m	()V	m_1114865	setupFog	
-	m	(Z)V	m_2557984		m_2557984
-		p	1			p_1
-	m	()V	m_6382667		m_6382667
-	m	(FFFF)Ljava/nio/FloatBuffer;	m_2787702		m_2787702
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
+	m	(Z)V	m_2557984		setLighting
+		p	1			enable
+	m	()V	m_6382667		setupFog
+	m	(FFFF)Ljava/nio/FloatBuffer;	m_2787702		getBuffer
+		p	1			f1
+		p	2			f2
+		p	3			f3
+		p	4			f4
 c	net/minecraft/unmapped/C_5283200
 	f	Lnet/minecraft/unmapped/C_3906126;	f_1045625	world	
 	f	Lnet/minecraft/unmapped/C_3466301;	f_3953567	blockRenderer	
@@ -1506,7 +1506,7 @@ c	net/minecraft/unmapped/C_5283200
 		p	2			originX
 		p	3			originY
 		p	4			originZ
-		p	5			p_5
+		p	5			size
 		p	6			glList
 	m	(Lcom/mojang/minecraft/player/Player;)F	m_9608130		squaredDistanceToCenter
 		p	1			camera
@@ -1524,8 +1524,8 @@ c	net/minecraft/unmapped/C_7564962
 	m	(Lcom/mojang/minecraft/player/Player;)V	m_5484011		m_5484011
 		p	1			p_1
 c	net/minecraft/unmapped/C_8425960
-	m	(Ljava/lang/String;)V	m_1434192		m_1434192
-		p	1			p_1
+	m	(Ljava/lang/String;)V	m_1434192		progressStart
+		p	1			title
 c	net/minecraft/unmapped/C_8688622
 	f	Lnet/minecraft/unmapped/C_5009044;	f_9491045	camera	
 	f	Lcom/mojang/minecraft/player/Player;	f_9491045		camera
@@ -1599,13 +1599,13 @@ c	net/minecraft/unmapped/C_0388903
 	m	(Ljava/io/File;)V	m_2685840		m_2685840
 		p	1			p_1
 c	net/minecraft/unmapped/C_1525636
-	f	I	f_6675555		f_6675555
+	f	I	f_6675555		slot
 c	net/minecraft/unmapped/C_5540851
-	f	Z	f_9717986		f_9717986
-	f	Ljavax/swing/JFileChooser;	f_8271264		f_8271264
-	f	Z	f_4651522		f_4651522
-	f	Ljava/io/File;	f_8809966		f_8809966
-	m	(Ljava/io/File;)V	m_2685840		m_2685840
+	f	Z	f_9717986		selecting
+	f	Ljavax/swing/JFileChooser;	f_8271264		fileChooser
+	f	Z	f_4651522		shouldSave
+	f	Ljava/io/File;	f_8809966		selectedFile
+	m	(Ljava/io/File;)V	m_2685840		handleSelection
 		p	1			p_1
 	m	()V	m_5056964		m_5056964
 	m	()V	m_7135145		m_7135145
@@ -1943,7 +1943,7 @@ c	com/mojang/minecraft/item/Arrow		com/mojang/minecraft/item/Arrow
 		p	1			p_1
 c	com/mojang/minecraft/item/Item		com/mojang/minecraft/item/Item
 	f	J	serialVersionUID		serialVersionUID
-	f	[Lnet/minecraft/unmapped/C_9882464;	f_5539600		f_5539600
+	f	[Lnet/minecraft/unmapped/C_9882464;	f_5539600		models
 	f	F	xd		xd
 	f	F	yd		yd
 	f	F	zd		zd
@@ -2893,7 +2893,7 @@ c	net/minecraft/unmapped/C_1133045		de/jarnbjo/vorbis/Mapping0
 	m	()[I	m_9055268		m_9055268
 	m	()I	m_9681215		m_9681215
 	m	()I	m_6247361		m_6247361
-c	net/minecraft/unmapped/C_1168442		net/minecraft/unmapped/C_1168442
+c	net/minecraft/unmapped/C_1168442		net/minecraft/client/render/model/entity/SheepFurModel
 	m	()V	<init>		<init>
 c	net/minecraft/unmapped/C_1602975		net/minecraft/unmapped/C_1602975
 	f	Lnet/minecraft/unmapped/C_6857610;	f_0567509		f_0567509
@@ -3052,7 +3052,7 @@ c	net/minecraft/unmapped/C_3160234		de/jarnbjo/vorbis/Floor0
 		p	2			p_2
 	m	([F)V	m_5525230		m_5525230
 		p	1			p_1
-c	net/minecraft/unmapped/C_3292694		net/minecraft/unmapped/C_3292694
+c	net/minecraft/unmapped/C_3292694		net/minecraft/client/render/model/entity/SkeletonModel
 	m	()V	<init>		<init>
 c	net/minecraft/unmapped/C_3464647		net/minecraft/client/network/ClientNetworkHandler
 	f	Ljava/io/ByteArrayOutputStream;	f_1074422		output
@@ -3116,18 +3116,18 @@ c	net/minecraft/unmapped/C_3600653		net/minecraft/network/packet/Packet
 	m	([Ljava/lang/Class;)V	<init>		<init>
 		p	1			dataTypes
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_4304615		net/minecraft/unmapped/C_4304615
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8977126		f_8977126
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9247043		f_9247043
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8893709		f_8893709
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9464243		f_9464243
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0852856		f_0852856
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0218467		f_0218467
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0996130		f_0996130
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6651414		f_6651414
-	f	Lnet/minecraft/unmapped/C_0289174;	f_9789835		f_9789835
-	f	Lnet/minecraft/unmapped/C_0289174;	f_7831538		f_7831538
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6302099		f_6302099
+c	net/minecraft/unmapped/C_4304615		net/minecraft/client/render/model/entity/SpiderEntity
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8977126		head
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9247043		neck
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8893709		body
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9464243		backRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0852856		backLeftLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0218467		backMiddleRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0996130		backMiddleLeftLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6651414		frontMiddleRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_9789835		frontMiddleLeftLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_7831538		frontRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6302099		frontLeftLeg
 	m	()V	<init>		<init>
 	m	(FFFFFF)V	m_2584069		m_2584069
 		p	1			p_1
@@ -3136,7 +3136,7 @@ c	net/minecraft/unmapped/C_4304615		net/minecraft/unmapped/C_4304615
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-c	net/minecraft/unmapped/C_4632560		net/minecraft/unmapped/C_4632560
+c	net/minecraft/unmapped/C_4632560		net/minecraft/client/render/model/entity/SheepModel
 	m	()V	<init>		<init>
 c	net/minecraft/unmapped/C_4811676		de/jarnbjo/vorbis/Residue2
 	m	()V	<init>		<init>
@@ -3296,19 +3296,19 @@ c	net/minecraft/unmapped/C_5791831$7680210		7680210
 	m	(Lnet/minecraft/unmapped/C_5791831;)V	<init>		<init>
 		p	1			p_1
 	m	()V	run		run
-c	net/minecraft/unmapped/C_6760097		net/minecraft/unmapped/C_6760097
-	f	Lnet/minecraft/unmapped/C_7898033;	f_4538254		f_4538254
-	f	Lnet/minecraft/unmapped/C_7898033;	f_0631287		f_0631287
-	f	Lnet/minecraft/unmapped/C_4590573;	f_5988746		f_5988746
-	f	Lnet/minecraft/unmapped/C_3292694;	f_2011282		f_2011282
-	f	Lnet/minecraft/unmapped/C_7237913;	f_7875334		f_7875334
-	f	Lnet/minecraft/unmapped/C_9823221;	f_5872396		f_5872396
-	f	Lnet/minecraft/unmapped/C_9823221;	f_6381842		f_6381842
-	f	Lnet/minecraft/unmapped/C_4304615;	f_9250233		f_9250233
-	f	Lnet/minecraft/unmapped/C_1168442;	f_7721878		f_7721878
+c	net/minecraft/unmapped/C_6760097		net/minecraft/client/render/model/ModelCache
+	f	Lnet/minecraft/unmapped/C_7898033;	f_4538254		humanoid
+	f	Lnet/minecraft/unmapped/C_7898033;	f_0631287		humanoidArmor
+	f	Lnet/minecraft/unmapped/C_4590573;	f_5988746		creeper
+	f	Lnet/minecraft/unmapped/C_3292694;	f_2011282		skeleton
+	f	Lnet/minecraft/unmapped/C_7237913;	f_7875334		zombie
+	f	Lnet/minecraft/unmapped/C_9823221;	f_5872396		pig
+	f	Lnet/minecraft/unmapped/C_9823221;	f_6381842		sheep
+	f	Lnet/minecraft/unmapped/C_4304615;	f_9250233		spider
+	f	Lnet/minecraft/unmapped/C_1168442;	f_7721878		sheepFur
 	m	()V	<init>		<init>
-	m	(Ljava/lang/String;)Lnet/minecraft/unmapped/C_3239917;	m_3976542		m_3976542
-		p	1			p_1
+	m	(Ljava/lang/String;)Lnet/minecraft/unmapped/C_3239917;	m_3976542		get
+		p	1			id
 c	net/minecraft/unmapped/C_6786807		net/minecraft/unmapped/C_6786807
 	f	Lcom/mojang/minecraft/Entity;	f_4225044		f_4225044
 	m	(Lcom/mojang/minecraft/Entity;Lcom/mojang/minecraft/Entity;)V	<init>		<init>
@@ -3395,7 +3395,7 @@ c	net/minecraft/unmapped/C_7120212		net/minecraft/block/BlockSound
 	m	()F	m_8797914		getVolume
 	m	()F	m_2550154		getPitch
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_7138722		net/minecraft/unmapped/C_7138722
+c	net/minecraft/unmapped/C_7138722		net/minecraft/client/render/model/entity/PigModel
 	m	()V	<init>		<init>
 c	net/minecraft/unmapped/C_7217122		net/minecraft/unmapped/C_7217122
 	f	F	f_6751841		f_6751841
@@ -3403,7 +3403,7 @@ c	net/minecraft/unmapped/C_7217122		net/minecraft/unmapped/C_7217122
 	m	([SI)I	m_2841446		m_2841446
 		p	1			p_1
 		p	2			p_2
-c	net/minecraft/unmapped/C_7237913		net/minecraft/unmapped/C_7237913
+c	net/minecraft/unmapped/C_7237913		net/minecraft/client/render/model/entity/ZombieModel
 	m	()V	<init>		<init>
 	m	(FFFFFF)V	m_5512614		m_5512614
 		p	1			p_1
@@ -3456,7 +3456,7 @@ c	net/minecraft/unmapped/C_7598507		net/minecraft/unmapped/C_7598507
 		p	2			p_2
 c	net/minecraft/unmapped/C_7898033		net/minecraft/client/render/model/entity/MobModel
 	f	Lnet/minecraft/unmapped/C_0289174;	f_6250892		head
-	f	Lnet/minecraft/unmapped/C_0289174;	f_3515609		f_3515609
+	f	Lnet/minecraft/unmapped/C_0289174;	f_3515609		hat
 	f	Lnet/minecraft/unmapped/C_0289174;	f_4812958		body
 	f	Lnet/minecraft/unmapped/C_0289174;	f_9339598		rightArm
 	f	Lnet/minecraft/unmapped/C_0289174;	f_7661525		leftArm
@@ -3464,7 +3464,7 @@ c	net/minecraft/unmapped/C_7898033		net/minecraft/client/render/model/entity/Mob
 	f	Lnet/minecraft/unmapped/C_0289174;	f_9956807		leftLeg
 	m	()V	<init>		<init>
 	m	(F)V	<init>		<init>
-		p	1			p_1
+		p	1			reduction
 	m	(FFFFFF)V	m_2584069		m_2584069
 		p	1			p_1
 		p	2			p_2
@@ -3472,13 +3472,13 @@ c	net/minecraft/unmapped/C_7898033		net/minecraft/client/render/model/entity/Mob
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-	m	(FFFFFF)V	m_5512614		m_5512614
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-		p	6			p_6
+	m	(FFFFFF)V	m_5512614		setupAnimation
+		p	1			walkAnimationProgress
+		p	2			walkAnimationSpeed
+		p	3			bob
+		p	4			yaw
+		p	5			pitch
+		p	6			scale
 c	net/minecraft/unmapped/C_7900390		de/jarnbjo/util/io/ByteArrayBitInputStream
 	f	[B	f_8612550		source
 	f	B	f_8992957		currentByte
@@ -3598,38 +3598,38 @@ c	net/minecraft/unmapped/C_9158347		net/minecraft/unmapped/C_9158347
 		p	2			p_2
 		p	3			p_3
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_9437404		net/minecraft/unmapped/C_9437404
-	f	Ljava/lang/String;	f_4623692		f_4623692
-	f	I	f_5528963		f_5528963
+c	net/minecraft/unmapped/C_9437404		net/minecraft/client/gui/ChatMessage
+	f	Ljava/lang/String;	f_4623692		text
+	f	I	f_5528963		age
 	m	(Ljava/lang/String;)V	<init>		<init>
 		p	1			p_1
-c	net/minecraft/unmapped/C_9665058		net/minecraft/unmapped/C_9665058
-	f	Lnet/minecraft/unmapped/C_8425960;	f_7071680		f_7071680
+c	net/minecraft/unmapped/C_9665058		net/minecraft/world/storage/WorldStorage
+	f	Lnet/minecraft/unmapped/C_8425960;	f_7071680		listener
 	m	(Lnet/minecraft/unmapped/C_8425960;)V	<init>		<init>
 		p	1			p_1
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/File;)Z	m_7243453		m_7243453
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/File;)Z	m_7243453		save
+		p	1			world
+		p	2			file
+	m	(Ljava/io/File;)Lcom/mojang/minecraft/level/Level;	m_2273715		load
 		p	1			p_1
-		p	2			p_2
-	m	(Ljava/io/File;)Lcom/mojang/minecraft/level/Level;	m_2273715		m_2273715
-		p	1			p_1
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734		m_5551734
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-		p	6			p_6
-	m	(Ljava/lang/String;Ljava/lang/String;I)Lcom/mojang/minecraft/level/Level;	m_2468514		m_2468514
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_7729189		m_7729189
-		p	1			p_1
-	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/OutputStream;)V	m_5611887		m_5611887
-		p	0			p_0
-		p	1			p_1
-	m	(Ljava/io/InputStream;)[B	m_8590209		m_8590209
-		p	0			p_0
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)Z	m_5551734		save
+		p	1			world
+		p	2			hostAddress
+		p	3			username
+		p	4			sessionId
+		p	5			name
+		p	6			slot
+	m	(Ljava/lang/String;Ljava/lang/String;I)Lcom/mojang/minecraft/level/Level;	m_2468514		load
+		p	1			hostAddress
+		p	2			username
+		p	3			slot
+	m	(Ljava/io/InputStream;)Lcom/mojang/minecraft/level/Level;	m_7729189		load
+		p	1			input
+	m	(Lcom/mojang/minecraft/level/Level;Ljava/io/OutputStream;)V	m_5611887		save
+		p	0			world
+		p	1			output
+	m	(Ljava/io/InputStream;)[B	m_8590209		readBlocks
+		p	0			input
 c	net/minecraft/unmapped/C_9722514		de/jarnbjo/vorbis/Residue0
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
 		p	1			p_1
@@ -3640,16 +3640,16 @@ c	net/minecraft/unmapped/C_9722514		de/jarnbjo/vorbis/Residue0
 		p	3			p_3
 		p	4			p_4
 		p	5			p_5
-c	net/minecraft/unmapped/C_9823221		net/minecraft/unmapped/C_9823221
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8509466		f_8509466
-	f	Lnet/minecraft/unmapped/C_0289174;	f_8035309		f_8035309
-	f	Lnet/minecraft/unmapped/C_0289174;	f_2619317		f_2619317
-	f	Lnet/minecraft/unmapped/C_0289174;	f_5376010		f_5376010
-	f	Lnet/minecraft/unmapped/C_0289174;	f_1202510		f_1202510
-	f	Lnet/minecraft/unmapped/C_0289174;	f_6231305		f_6231305
+c	net/minecraft/unmapped/C_9823221		net/minecraft/client/render/model/entity/QuadrupedModel
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8509466		head
+	f	Lnet/minecraft/unmapped/C_0289174;	f_8035309		body
+	f	Lnet/minecraft/unmapped/C_0289174;	f_2619317		backRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_5376010		backLeftLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_1202510		frontRightLeg
+	f	Lnet/minecraft/unmapped/C_0289174;	f_6231305		frontLeftLeg
 	m	(IF)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
+		p	1			pivotPoint
+		p	2			reduction
 	m	(FFFFFF)V	m_2584069		m_2584069
 		p	1			p_1
 		p	2			p_2
@@ -3657,8 +3657,8 @@ c	net/minecraft/unmapped/C_9823221		net/minecraft/unmapped/C_9823221
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-c	net/minecraft/unmapped/C_9882464		net/minecraft/unmapped/C_9882464
-	f	Lnet/minecraft/unmapped/C_0289174;	f_0436548		f_0436548
+c	net/minecraft/unmapped/C_9882464		net/minecraft/client/render/model/BlockModel
+	f	Lnet/minecraft/unmapped/C_0289174;	f_0436548		part
 	m	(I)V	<init>		<init>
-		p	1			p_1
-	m	()V	m_1955164		m_1955164
+		p	1			sprite
+	m	()V	m_1955164		render

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -641,23 +641,23 @@ c	net/minecraft/unmapped/C_4078372
 	f	I	f_3160490	sizeY	
 	f	[B	f_5268170	blocks	
 	f	I	f_9811652	surroundingWaterHeight	
-	f	I	f_7275613		f_7275613
-	f	I	f_8175346		f_8175346
-	f	I	f_2316345		f_2316345
-	f	[B	f_8316515		f_8316515
+	f	I	f_7275613		sizeX
+	f	I	f_8175346		sizeZ
+	f	I	f_2316345		sizeY
+	f	[B	f_8316515		blocks
 	f	I	f_2661209		f_2661209
 	m	(IIII)V	m_8354142	placeOre	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
-	m	(Ljava/lang/String;III)Lcom/mojang/minecraft/level/Level;	m_0447977		m_0447977
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-	m	(IIII)V	m_9667175		m_9667175
-		p	1			p_1
+	m	(Ljava/lang/String;III)Lcom/mojang/minecraft/level/Level;	m_0447977		generate
+		p	1			name
+		p	2			sizeX
+		p	3			sizeZ
+		p	4			sizeY
+	m	(IIII)V	m_9667175		placeOre
+		p	1			block
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
@@ -3497,8 +3497,8 @@ c	net/minecraft/unmapped/C_7900390		de/jarnbjo/util/io/ByteArrayBitInputStream
 		p	1			root
 	m	(I)J	m_1016947		getLong
 		p	1			bits
-c	net/minecraft/unmapped/C_8100347		net/minecraft/unmapped/C_8100347
-	f	Ljava/util/Set;	f_9798909		f_9798909
+c	net/minecraft/unmapped/C_8100347		net/minecraft/world/storage/EntityObjectInputStream
+	f	Ljava/util/Set;	f_9798909		types
 	m	(Ljava/io/InputStream;)V	<init>		<init>
 		p	1			p_1
 	m	()Ljava/io/ObjectStreamClass;	readClassDescriptor		readClassDescriptor

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -3093,7 +3093,7 @@ c	net/minecraft/unmapped/C_3464647$6170244		6170244
 		p	6			p_6
 	m	()V	run		run
 c	net/minecraft/unmapped/C_3600653		net/minecraft/network/packet/Packet
-	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191		PACKETS
+	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191		BY_ID
 	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308		LOGIN
 	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768		PING
 	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207		WORLD_CHUNK

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -1063,12 +1063,12 @@ c	net/minecraft/client/Minecraft
 	f	Lcom/mojang/minecraft/level/Level;	f_5337597		world
 	f	Lcom/mojang/minecraft/player/Player;	f_5473933		player
 	f	Lnet/minecraft/unmapped/C_9665058;	f_1737492		worldStorage
-	f	Lnet/minecraft/unmapped/C_7598507;	f_2497216		f_2497216
+	f	Lnet/minecraft/unmapped/C_7598507;	f_2497216		sounds
 	f	Ljava/lang/String;	f_6753290		loadmapUser
 	f	I	f_5242116		loadmapId
 	f	Z	f_4909729		skipGameRender
 	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748		networkHandler
-	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934		f_1501934
+	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934		soundEngine
 	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645		applet
 	f	I	f_0132506		startupServerPort
 	m	(Lnet/minecraft/unmapped/C_3906126;)V	m_6427459	setWorld	
@@ -2852,12 +2852,12 @@ c	net/minecraft/unmapped/C_0091050		de/jarnbjo/vorbis/Residue
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073		getLook
 		p	1			source
 		p	2			key
-c	net/minecraft/unmapped/C_0190332		net/minecraft/unmapped/C_0190332
+c	net/minecraft/unmapped/C_0190332		net/minecraft/client/sound/VorbisCodec
 	m	()V	<init>		<init>
-	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032		m_3617032
+	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032		load
 		p	0			p_0
 c	net/minecraft/unmapped/C_0322130		de/jarnbjo/vorbis/VorbisStream
-	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447		f_3883447
+	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447		oggStream
 	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360		identificationHeader
 	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945		commentHeader
 	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100		setupHeader
@@ -2895,14 +2895,14 @@ c	net/minecraft/unmapped/C_1133045		de/jarnbjo/vorbis/Mapping0
 	m	()I	m_6247361		m_6247361
 c	net/minecraft/unmapped/C_1168442		net/minecraft/client/render/model/entity/SheepFurModel
 	m	()V	<init>		<init>
-c	net/minecraft/unmapped/C_1602975		net/minecraft/unmapped/C_1602975
-	f	Lnet/minecraft/unmapped/C_6857610;	f_0567509		f_0567509
-	f	F	f_3867104		f_3867104
-	f	F	f_0155570		f_0155570
+c	net/minecraft/unmapped/C_1602975		net/minecraft/client/sound/buffer/SimpleSoundBuffer
+	f	Lnet/minecraft/unmapped/C_6857610;	f_0567509		sound
+	f	F	f_3867104		position
+	f	F	f_0155570		pitch
 	m	(Lnet/minecraft/unmapped/C_6857610;FF)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
+		p	2			pitch
+		p	3			volume
 	m	([SI)I	m_2841446		m_2841446
 		p	1			p_1
 		p	2			p_2
@@ -2997,11 +2997,11 @@ c	net/minecraft/unmapped/C_1861953		de/jarnbjo/ogg/OggPage
 		p	0			source
 		p	1			buffer
 	m	()I	m_4618783		getTotalLength
-c	net/minecraft/unmapped/C_1996769		net/minecraft/unmapped/C_1996769
-	m	([I[II)Z	m_6552350		m_6552350
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
+c	net/minecraft/unmapped/C_1996769		net/minecraft/client/sound/source/SoundSource
+	m	([I[II)Z	m_6552350		play
+		p	1			leftChannel
+		p	2			rightChannel
+		p	3			sampleCount
 c	net/minecraft/unmapped/C_2122471		de/jarnbjo/vorbis/Util
 	m	()V	<init>		<init>
 	m	(I)I	m_3224692		ilog
@@ -3151,7 +3151,7 @@ c	net/minecraft/unmapped/C_4811676		de/jarnbjo/vorbis/Residue2
 		p	5			p_5
 	m	()Ljava/lang/Object;	clone		clone
 c	net/minecraft/unmapped/C_4958210		de/jarnbjo/ogg/LogicalOggStreamImpl
-	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799		f_9154799
+	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799		source
 	f	Ljava/util/ArrayList;	f_2795626		pageNumberMapping
 	f	I	f_4763122		pageIndex
 	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523		currentPage
@@ -3225,7 +3225,7 @@ c	net/minecraft/unmapped/C_5664626		de/jarnbjo/vorbis/CodeBook
 	m	([I)Z	m_8448942		createHuffmanTree
 		p	1			entryLengths
 c	net/minecraft/unmapped/C_5718344		de/jarnbjo/vorbis/MdctFloat
-	f	I	f_3569804		f_3569804
+	f	I	f_3569804		n
 	f	I	f_7581426		log2n
 	f	[F	f_4416437		trig
 	f	[I	f_3575069		bitrev
@@ -3275,15 +3275,15 @@ c	net/minecraft/unmapped/C_5765318		de/jarnbjo/vorbis/Floor1
 		p	1			p_1
 	m	()Ljava/lang/Object;	clone		clone
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_5791831		net/minecraft/unmapped/C_5791831
-	f	Ljava/nio/ByteBuffer;	f_1311242		f_1311242
-	f	Ljava/nio/ByteBuffer;	f_9842249		f_9842249
-	f	Ljava/nio/ByteBuffer;	f_0920360		f_0920360
-	f	Ljava/nio/ByteBuffer;	f_9322493		f_9322493
-	f	Lnet/minecraft/unmapped/C_0322130;	f_6710886		f_6710886
-	f	Lnet/minecraft/unmapped/C_8534347;	f_9139123		f_9139123
-	f	Z	f_5499651		f_5499651
-	f	Z	f_1930601		f_1930601
+c	net/minecraft/unmapped/C_5791831		net/minecraft/client/sound/source/StreamingSoundSource
+	f	Ljava/nio/ByteBuffer;	f_1311242		vorbisBuffer
+	f	Ljava/nio/ByteBuffer;	f_9842249		lastBuffer
+	f	Ljava/nio/ByteBuffer;	f_0920360		currentBuffer
+	f	Ljava/nio/ByteBuffer;	f_9322493		nextBuffer
+	f	Lnet/minecraft/unmapped/C_0322130;	f_6710886		vorbis
+	f	Lnet/minecraft/unmapped/C_8534347;	f_9139123		engine
+	f	Z	f_5499651		finished
+	f	Z	f_1930601		terminated
 	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/net/URL;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
@@ -3309,11 +3309,11 @@ c	net/minecraft/unmapped/C_6760097		net/minecraft/client/render/model/ModelCache
 	m	()V	<init>		<init>
 	m	(Ljava/lang/String;)Lnet/minecraft/unmapped/C_3239917;	m_3976542		get
 		p	1			id
-c	net/minecraft/unmapped/C_6786807		net/minecraft/unmapped/C_6786807
-	f	Lcom/mojang/minecraft/Entity;	f_4225044		f_4225044
+c	net/minecraft/unmapped/C_6786807		net/minecraft/client/sound/effect/EntitySoundEffect
+	f	Lcom/mojang/minecraft/Entity;	f_4225044		source
 	m	(Lcom/mojang/minecraft/Entity;Lcom/mojang/minecraft/Entity;)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
+		p	2			listener
 	m	()F	m_4192289		m_4192289
 	m	()F	m_2230278		m_2230278
 c	net/minecraft/unmapped/C_6848444		de/jarnbjo/vorbis/Floor
@@ -3328,9 +3328,9 @@ c	net/minecraft/unmapped/C_6848444		de/jarnbjo/vorbis/Floor
 	m	([F)V	m_5525230		computeFloor
 		p	1			vector
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_6857610		net/minecraft/unmapped/C_6857610
-	f	[S	f_2102733		f_2102733
-	f	F	f_0816698		f_0816698
+c	net/minecraft/unmapped/C_6857610		net/minecraft/client/sound/Sound
+	f	[S	f_2102733		samples
+	f	F	f_0816698		sampleRate
 	m	([SF)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
@@ -3347,9 +3347,9 @@ c	net/minecraft/unmapped/C_6908252		de/jarnbjo/vorbis/Mapping
 	m	()[I	m_9055268		getSubmapResidues
 	m	()I	m_9681215		getCouplingSteps
 	m	()I	m_6247361		getSubmaps
-c	net/minecraft/unmapped/C_6975176		net/minecraft/unmapped/C_6975176
-	m	()F	m_4192289		m_4192289
-	m	()F	m_2230278		m_2230278
+c	net/minecraft/unmapped/C_6975176		net/minecraft/client/sound/effect/SoundEffect
+	m	()F	m_4192289		getPan
+	m	()F	m_2230278		getVolume
 c	net/minecraft/unmapped/C_7018681		net/minecraft/entity/mob/player/PlayerTransform
 	f	F	f_6477721		x
 	f	F	f_7870468		y
@@ -3397,12 +3397,12 @@ c	net/minecraft/unmapped/C_7120212		net/minecraft/block/BlockSound
 	m	()V	<clinit>		<clinit>
 c	net/minecraft/unmapped/C_7138722		net/minecraft/client/render/model/entity/PigModel
 	m	()V	<init>		<init>
-c	net/minecraft/unmapped/C_7217122		net/minecraft/unmapped/C_7217122
-	f	F	f_6751841		f_6751841
+c	net/minecraft/unmapped/C_7217122		net/minecraft/client/sound/buffer/SoundBuffer
+	f	F	f_6751841		volume
 	m	()V	<init>		<init>
-	m	([SI)I	m_2841446		m_2841446
-		p	1			p_1
-		p	2			p_2
+	m	([SI)I	m_2841446		read
+		p	1			samples
+		p	2			sampleCount
 c	net/minecraft/unmapped/C_7237913		net/minecraft/client/render/model/entity/ZombieModel
 	m	()V	<init>		<init>
 	m	(FFFFFF)V	m_5512614		m_5512614
@@ -3412,48 +3412,48 @@ c	net/minecraft/unmapped/C_7237913		net/minecraft/client/render/model/entity/Zom
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-c	net/minecraft/unmapped/C_7421241		net/minecraft/unmapped/C_7421241
-	f	F	f_7913003		f_7913003
-	f	F	f_5482103		f_5482103
-	f	F	f_9948499		f_9948499
+c	net/minecraft/unmapped/C_7421241		net/minecraft/client/sound/effect/PositionSoundEffect
+	f	F	f_7913003		x
+	f	F	f_5482103		y
+	f	F	f_9948499		z
 	m	(FFFLcom/mojang/minecraft/Entity;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
-		p	4			p_4
+		p	4			listener
 	m	()F	m_4192289		m_4192289
 	m	()F	m_2230278		m_2230278
-c	net/minecraft/unmapped/C_7518437		net/minecraft/unmapped/C_7518437
-	f	Lcom/mojang/minecraft/Entity;	f_5561345		f_5561345
+c	net/minecraft/unmapped/C_7518437		net/minecraft/client/sound/effect/StereoSoundEffect
+	f	Lcom/mojang/minecraft/Entity;	f_5561345		listener
 	m	(Lcom/mojang/minecraft/Entity;)V	<init>		<init>
 		p	1			p_1
-	m	(FF)F	m_0724724		m_0724724
-		p	1			p_1
-		p	2			p_2
-	m	(FFF)F	m_5736595		m_5736595
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-c	net/minecraft/unmapped/C_7598507		net/minecraft/unmapped/C_7598507
-	f	Lnet/minecraft/unmapped/C_0190332;	f_7276700		f_7276700
-	f	Ljava/util/Map;	f_7131455		f_7131455
-	f	Ljava/util/Map;	f_1040873		f_1040873
-	f	Ljava/util/Random;	f_9006459		f_9006459
-	f	J	f_8766128		f_8766128
+	m	(FF)F	m_0724724		getPan
+		p	1			x
+		p	2			z
+	m	(FFF)F	m_5736595		getVolume
+		p	1			x
+		p	2			y
+		p	3			z
+c	net/minecraft/unmapped/C_7598507		net/minecraft/client/sound/Sounds
+	f	Lnet/minecraft/unmapped/C_0190332;	f_7276700		codec
+	f	Ljava/util/Map;	f_7131455		sounds
+	f	Ljava/util/Map;	f_1040873		records
+	f	Ljava/util/Random;	f_9006459		random
+	f	J	f_8766128		musicTime
 	m	()V	<init>		<init>
-	m	(Ljava/lang/String;FF)Lnet/minecraft/unmapped/C_7217122;	m_5004797		m_5004797
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-	m	(Ljava/io/File;Ljava/lang/String;)V	m_6216168		m_6216168
-		p	1			p_1
-		p	2			p_2
-	m	(Ljava/lang/String;Ljava/io/File;)V	m_1222136		m_1222136
-		p	1			p_1
-		p	2			p_2
-	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/lang/String;)Z	m_6859432		m_6859432
-		p	1			p_1
-		p	2			p_2
+	m	(Ljava/lang/String;FF)Lnet/minecraft/unmapped/C_7217122;	m_5004797		getRandom
+		p	1			path
+		p	2			volume
+		p	3			pitch
+	m	(Ljava/io/File;Ljava/lang/String;)V	m_6216168		add
+		p	1			file
+		p	2			path
+	m	(Ljava/lang/String;Ljava/io/File;)V	m_1222136		addRecord
+		p	1			path
+		p	2			file
+	m	(Lnet/minecraft/unmapped/C_8534347;Ljava/lang/String;)Z	m_6859432		playRandomRecord
+		p	1			engine
+		p	2			path
 c	net/minecraft/unmapped/C_7898033		net/minecraft/client/render/model/entity/MobModel
 	f	Lnet/minecraft/unmapped/C_0289174;	f_6250892		head
 	f	Lnet/minecraft/unmapped/C_0289174;	f_3515609		hat
@@ -3531,17 +3531,17 @@ c	net/minecraft/unmapped/C_8423483		de/jarnbjo/vorbis/AudioPacket
 		p	1			previousPacket
 		p	2			buffer
 	m	()V	<clinit>		<clinit>
-c	net/minecraft/unmapped/C_8534347		net/minecraft/unmapped/C_8534347
-	f	Z	f_3030770		f_3030770
-	f	Ljavax/sound/sampled/SourceDataLine;	f_9674275		f_9674275
-	f	Ljava/util/List;	f_0650018		f_0650018
-	f	Lnet/minecraft/unmapped/C_7688744;	f_2958002		f_2958002
+c	net/minecraft/unmapped/C_8534347		net/minecraft/client/sound/SoundEngine
+	f	Z	f_3030770		running
+	f	Ljavax/sound/sampled/SourceDataLine;	f_9674275		audioDataLine
+	f	Ljava/util/List;	f_0650018		sources
+	f	Lnet/minecraft/unmapped/C_7688744;	f_2958002		options
 	m	(Lnet/minecraft/unmapped/C_7688744;)V	<init>		<init>
 		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_1996769;)V	m_3604784		m_3604784
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	m_5327400		m_5327400
-		p	1			p_1
+	m	(Lnet/minecraft/unmapped/C_1996769;)V	m_3604784		play
+		p	1			source
+	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	m_5327400		play
+		p	1			buffer
 		p	2			p_2
 	m	()V	run		run
 c	net/minecraft/unmapped/C_8560236		de/jarnbjo/util/io/HuffmanNode
@@ -3584,12 +3584,12 @@ c	net/minecraft/unmapped/C_8995754		net/minecraft/network/Connection
 		p	2			payload
 	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968		read
 		p	1			type
-c	net/minecraft/unmapped/C_9158347		net/minecraft/unmapped/C_9158347
-	f	Lnet/minecraft/unmapped/C_7217122;	f_9317684		f_9317684
-	f	Lnet/minecraft/unmapped/C_6975176;	f_4348730		f_4348730
-	f	F	f_1051437		f_1051437
-	f	F	f_2764470		f_2764470
-	f	[S	f_6950351		f_6950351
+c	net/minecraft/unmapped/C_9158347		net/minecraft/client/sound/source/SimpleSoundSource
+	f	Lnet/minecraft/unmapped/C_7217122;	f_9317684		buffer
+	f	Lnet/minecraft/unmapped/C_6975176;	f_4348730		effect
+	f	F	f_1051437		pan
+	f	F	f_2764470		volume
+	f	[S	f_6950351		sampleBuffer
 	m	(Lnet/minecraft/unmapped/C_7217122;Lnet/minecraft/unmapped/C_6975176;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -1067,7 +1067,7 @@ c	net/minecraft/client/Minecraft
 	f	Ljava/lang/String;	f_6753290		f_6753290
 	f	I	f_5242116		f_5242116
 	f	Z	f_4909729		f_4909729
-	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748		f_9951748
+	f	Lnet/minecraft/unmapped/C_3464647;	f_9951748		networkHandler
 	f	Lnet/minecraft/unmapped/C_8534347;	f_1501934		f_1501934
 	f	Lcom/mojang/minecraft/MinecraftApplet;	f_0976645		f_0976645
 	f	I	f_0132506		f_0132506
@@ -3054,29 +3054,29 @@ c	net/minecraft/unmapped/C_3160234		de/jarnbjo/vorbis/Floor0
 		p	1			p_1
 c	net/minecraft/unmapped/C_3292694		net/minecraft/unmapped/C_3292694
 	m	()V	<init>		<init>
-c	net/minecraft/unmapped/C_3464647		net/minecraft/unmapped/C_3464647
-	f	Ljava/io/ByteArrayOutputStream;	f_1074422		f_1074422
-	f	Lnet/minecraft/unmapped/C_8995754;	f_6951774		f_6951774
+c	net/minecraft/unmapped/C_3464647		net/minecraft/client/network/ClientNetworkHandler
+	f	Ljava/io/ByteArrayOutputStream;	f_1074422		output
+	f	Lnet/minecraft/unmapped/C_8995754;	f_6951774		conection
 	f	Lnet/minecraft/client/Minecraft;	f_1892126		f_1892126
-	f	Z	f_7137415		f_7137415
-	f	Z	f_1094396		f_1094396
-	f	Ljava/util/HashMap;	f_4932152		f_4932152
+	f	Z	f_7137415		connected
+	f	Z	f_1094396		loaded
+	f	Ljava/util/HashMap;	f_4932152		players
 	m	(Lnet/minecraft/client/Minecraft;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-	m	(IIIII)V	m_8042486		m_8042486
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-	m	(Ljava/lang/Exception;)V	m_3938439		m_3938439
-		p	1			p_1
-	m	()Z	m_3898071		m_3898071
-	m	()Ljava/util/List;	m_8518413		m_8518413
+		p	2			address
+		p	3			port
+		p	4			username
+		p	5			password
+	m	(IIIII)V	m_8042486		setBlock
+		p	1			x
+		p	2			y
+		p	3			z
+		p	4			mode
+		p	5			block
+	m	(Ljava/lang/Exception;)V	m_3938439		handleException
+		p	1			exception
+	m	()Z	m_3898071		isConnected
+	m	()Ljava/util/List;	m_8518413		getPlayers
 c	net/minecraft/unmapped/C_3464647$6170244		6170244
 	f	Ljava/lang/String;	f_1031671		f_1031671
 	f	I	f_1951524		f_1951524
@@ -3092,29 +3092,29 @@ c	net/minecraft/unmapped/C_3464647$6170244		6170244
 		p	5			p_5
 		p	6			p_6
 	m	()V	run		run
-c	net/minecraft/unmapped/C_3600653		net/minecraft/unmapped/C_3600653
-	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191		f_7217191
-	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308		f_3149308
-	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768		f_4461768
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207		f_5289207
-	f	Lnet/minecraft/unmapped/C_3600653;	f_8546696		f_8546696
-	f	Lnet/minecraft/unmapped/C_3600653;	f_2373056		f_2373056
-	f	Lnet/minecraft/unmapped/C_3600653;	f_3895897		f_3895897
-	f	Lnet/minecraft/unmapped/C_3600653;	f_7782816		f_7782816
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5917851		f_5917851
-	f	Lnet/minecraft/unmapped/C_3600653;	f_6187456		f_6187456
-	f	Lnet/minecraft/unmapped/C_3600653;	f_9528793		f_9528793
-	f	Lnet/minecraft/unmapped/C_3600653;	f_6653682		f_6653682
-	f	Lnet/minecraft/unmapped/C_3600653;	f_7798170		f_7798170
-	f	Lnet/minecraft/unmapped/C_3600653;	f_0872420		f_0872420
-	f	Lnet/minecraft/unmapped/C_3600653;	f_5317033		f_5317033
-	f	Lnet/minecraft/unmapped/C_3600653;	f_4805617		f_4805617
-	f	I	f_7304734		f_7304734
-	f	I	f_5406195		f_5406195
-	f	B	f_6782781		f_6782781
-	f	[Ljava/lang/Class;	f_8463791		f_8463791
+c	net/minecraft/unmapped/C_3600653		net/minecraft/network/packet/Packet
+	f	[Lnet/minecraft/unmapped/C_3600653;	f_7217191		PACKETS
+	f	Lnet/minecraft/unmapped/C_3600653;	f_3149308		LOGIN
+	f	Lnet/minecraft/unmapped/C_3600653;	f_4461768		PING
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5289207		WORLD_CHUNK
+	f	Lnet/minecraft/unmapped/C_3600653;	f_8546696		WORLD_SIZE
+	f	Lnet/minecraft/unmapped/C_3600653;	f_2373056		SET_BLOCK
+	f	Lnet/minecraft/unmapped/C_3600653;	f_3895897		BLOCK_UPDATE
+	f	Lnet/minecraft/unmapped/C_3600653;	f_7782816		ADD_PLAYER
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5917851		PLAYER_TELEPORT
+	f	Lnet/minecraft/unmapped/C_3600653;	f_6187456		PLAYER_MOVE
+	f	Lnet/minecraft/unmapped/C_3600653;	f_9528793		PLAYER_VELOCITY
+	f	Lnet/minecraft/unmapped/C_3600653;	f_6653682		PLAYER_ROTATE
+	f	Lnet/minecraft/unmapped/C_3600653;	f_7798170		REMOVE_PLAYER
+	f	Lnet/minecraft/unmapped/C_3600653;	f_0872420		MESSAGE
+	f	Lnet/minecraft/unmapped/C_3600653;	f_5317033		DISCONNECT
+	f	Lnet/minecraft/unmapped/C_3600653;	f_4805617		UPDATE_USER_TYPE
+	f	I	f_7304734		size
+	f	I	f_5406195		lastId
+	f	B	f_6782781		id
+	f	[Ljava/lang/Class;	f_8463791		dataTypes
 	m	([Ljava/lang/Class;)V	<init>		<init>
-		p	1			p_1
+		p	1			dataTypes
 	m	()V	<clinit>		<clinit>
 c	net/minecraft/unmapped/C_4304615		net/minecraft/unmapped/C_4304615
 	f	Lnet/minecraft/unmapped/C_0289174;	f_8977126		f_8977126
@@ -3197,9 +3197,9 @@ c	net/minecraft/unmapped/C_5044387		net/minecraft/client/SurvivalInteractionMana
 	m	()V	m_9782821		m_9782821
 	m	(Lcom/mojang/minecraft/level/Level;)V	m_9869738		m_9869738
 		p	1			p_1
-c	net/minecraft/unmapped/C_5169041		net/minecraft/unmapped/C_5169041
-	f	Ljava/lang/String;	f_0533128		f_0533128
-	f	I	f_9208767		f_9208767
+c	net/minecraft/unmapped/C_5169041		net/minecraft/client/gui/screen/ChatScreen
+	f	Ljava/lang/String;	f_0533128		lastChatMessage
+	f	I	f_9208767		ticks
 	m	()V	<init>		<init>
 	m	()V	m_2060594		m_2060594
 	m	()V	m_5056964		m_5056964
@@ -3350,14 +3350,14 @@ c	net/minecraft/unmapped/C_6908252		de/jarnbjo/vorbis/Mapping
 c	net/minecraft/unmapped/C_6975176		net/minecraft/unmapped/C_6975176
 	m	()F	m_4192289		m_4192289
 	m	()F	m_2230278		m_2230278
-c	net/minecraft/unmapped/C_7018681		net/minecraft/unmapped/C_7018681
-	f	F	f_6477721		f_6477721
-	f	F	f_7870468		f_7870468
-	f	F	f_0110066		f_0110066
-	f	F	f_2382842		f_2382842
-	f	F	f_1369203		f_1369203
-	f	Z	f_5972456		f_5972456
-	f	Z	f_9167360		f_9167360
+c	net/minecraft/unmapped/C_7018681		net/minecraft/entity/mob/player/PlayerTransform
+	f	F	f_6477721		x
+	f	F	f_7870468		y
+	f	F	f_0110066		z
+	f	F	f_2382842		yaw
+	f	F	f_1369203		pitch
+	f	Z	f_5972456		position
+	f	Z	f_9167360		rotation
 	m	(FFFFF)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
@@ -3566,24 +3566,24 @@ c	net/minecraft/unmapped/C_8903842		de/jarnbjo/vorbis/CommentHeader
 		p	1			source
 	m	(Lnet/minecraft/unmapped/C_7900390;)Ljava/lang/String;	m_1750090		getString
 		p	0			source
-c	net/minecraft/unmapped/C_8995754		net/minecraft/unmapped/C_8995754
-	f	Z	f_8629289		f_8629289
-	f	Ljava/nio/channels/SocketChannel;	f_6794126		f_6794126
-	f	Ljava/nio/ByteBuffer;	f_1990451		f_1990451
-	f	Ljava/nio/ByteBuffer;	f_4137365		f_4137365
-	f	Lnet/minecraft/unmapped/C_3464647;	f_9596163		f_9596163
-	f	Ljava/net/Socket;	f_0307332		f_0307332
+c	net/minecraft/unmapped/C_8995754		net/minecraft/network/Connection
+	f	Z	f_8629289		open
+	f	Ljava/nio/channels/SocketChannel;	f_6794126		channel
+	f	Ljava/nio/ByteBuffer;	f_1990451		input
+	f	Ljava/nio/ByteBuffer;	f_4137365		output
+	f	Lnet/minecraft/unmapped/C_3464647;	f_9596163		listener
+	f	Ljava/net/Socket;	f_0307332		socket
 	f	Z	f_3124921		f_3124921
-	f	[B	f_8341920		f_8341920
+	f	[B	f_8341920		stringBuffer
 	m	(Ljava/lang/String;I)V	<init>		<init>
-		p	1			p_1
+		p	1			address
 		p	2			p_2
-	m	()V	m_3957784		m_3957784
-	m	(Lnet/minecraft/unmapped/C_3600653;[Ljava/lang/Object;)V	m_9207877		m_9207877
-		p	1			p_1
-		p	2			p_2
-	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968		m_9294968
-		p	1			p_1
+	m	()V	m_3957784		close
+	m	(Lnet/minecraft/unmapped/C_3600653;[Ljava/lang/Object;)V	m_9207877		send
+		p	1			packet
+		p	2			payload
+	m	(Ljava/lang/Class;)Ljava/lang/Object;	m_9294968		read
+		p	1			type
 c	net/minecraft/unmapped/C_9158347		net/minecraft/unmapped/C_9158347
 	f	Lnet/minecraft/unmapped/C_7217122;	f_9317684		f_9317684
 	f	Lnet/minecraft/unmapped/C_6975176;	f_4348730		f_4348730

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -2818,74 +2818,74 @@ c	com/mojang/minecraft/player/Player$1		1
 	m	(Lcom/mojang/minecraft/player/Player;)V	<init>		<init>
 		p	1			p_1
 	m	()V	update		update
-c	net/minecraft/unmapped/C_0091050		net/minecraft/unmapped/C_0091050
-	f	I	f_6751262		f_6751262
-	f	I	f_1842919		f_1842919
-	f	I	f_0262118		f_0262118
-	f	I	f_9191803		f_9191803
-	f	I	f_6604920		f_6604920
-	f	[I	f_6243398		f_6243398
-	f	[[I	f_1032081		f_1032081
-	f	Ljava/util/HashMap;	f_4109781		f_4109781
+c	net/minecraft/unmapped/C_0091050		de/jarnbjo/vorbis/Residue
+	f	I	f_6751262		begin
+	f	I	f_1842919		end
+	f	I	f_0262118		partitionSize
+	f	I	f_9191803		classifications
+	f	I	f_6604920		classBook
+	f	[I	f_6243398		cascade
+	f	[[I	f_1032081		books
+	f	Ljava/util/HashMap;	f_4109781		looks
 	m	()V	<init>		<init>
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_0091050;	m_5224066		m_5224066
-		p	0			p_0
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_2214843;[Z[[F)V	m_8112343		m_8112343
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-	m	()I	m_7334930		m_7334930
-	m	()I	m_5680415		m_5680415
-	m	()I	m_0954887		m_0954887
-	m	()I	m_8900682		m_8900682
-	m	()I	m_6433054		m_6433054
-	m	()[I	m_3528011		m_3528011
-	m	()[[I	m_7464039		m_7464039
-	m	(Lnet/minecraft/unmapped/C_0091050;)V	m_4937135		m_4937135
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073		m_6933073
-		p	1			p_1
-		p	2			p_2
+		p	1			source
+		p	2			header
+	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_0091050;	m_5224066		createInstance
+		p	0			source
+		p	1			header
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_2214843;[Z[[F)V	m_8112343		decodeResidue
+		p	1			vorbis
+		p	2			source
+		p	3			mode
+		p	4			doNotDecodeFlags
+		p	5			vectors
+	m	()I	m_7334930		getBegin
+	m	()I	m_5680415		getEnd
+	m	()I	m_0954887		getPartitionSize
+	m	()I	m_8900682		getClassifications
+	m	()I	m_6433054		getClassBook
+	m	()[I	m_3528011		getCascade
+	m	()[[I	m_7464039		getBooks
+	m	(Lnet/minecraft/unmapped/C_0091050;)V	m_4937135		fill
+		p	1			clone
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)Lnet/minecraft/unmapped/C_1695696;	m_6933073		getLook
+		p	1			source
+		p	2			key
 c	net/minecraft/unmapped/C_0190332		net/minecraft/unmapped/C_0190332
 	m	()V	<init>		<init>
 	m	(Ljava/net/URL;)Lnet/minecraft/unmapped/C_6857610;	m_3617032		m_3617032
 		p	0			p_0
-c	net/minecraft/unmapped/C_0322130		net/minecraft/unmapped/C_0322130
+c	net/minecraft/unmapped/C_0322130		de/jarnbjo/vorbis/VorbisStream
 	f	Lnet/minecraft/unmapped/C_4958210;	f_3883447		f_3883447
-	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360		f_4208360
-	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945		f_1100945
-	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100		f_4347100
-	f	Lnet/minecraft/unmapped/C_8423483;	f_5239443		f_5239443
-	f	[B	f_8032923		f_8032923
-	f	I	f_6949479		f_6949479
-	f	I	f_8986025		f_8986025
-	f	Ljava/lang/Object;	f_5704116		f_5704116
-	f	I	f_2640606		f_2640606
-	f	J	f_6171484		f_6171484
+	f	Lnet/minecraft/unmapped/C_1703365;	f_4208360		identificationHeader
+	f	Lnet/minecraft/unmapped/C_8903842;	f_1100945		commentHeader
+	f	Lnet/minecraft/unmapped/C_5753145;	f_4347100		setupHeader
+	f	Lnet/minecraft/unmapped/C_8423483;	f_5239443		lastAudioPacket
+	f	[B	f_8032923		currentPcm
+	f	I	f_6949479		currentPcmIndex
+	f	I	f_8986025		currentPcmLimit
+	f	Ljava/lang/Object;	f_5704116		streamLock
+	f	I	f_2640606		currentBitRate
+	f	J	f_6171484		currentGranulePosition
 	m	()V	<init>		<init>
 	m	(Lnet/minecraft/unmapped/C_4958210;)V	<init>		<init>
-		p	1			p_1
-	m	([BII)I	m_1114472		m_1114472
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-	m	()Lnet/minecraft/unmapped/C_8423483;	m_0842369		m_0842369
-c	net/minecraft/unmapped/C_1133045		net/minecraft/unmapped/C_1133045
-	f	[I	f_5045799		f_5045799
-	f	[I	f_2332401		f_2332401
-	f	[I	f_9277376		f_9277376
-	f	[I	f_5258898		f_5258898
-	f	[I	f_5326611		f_5326611
+		p	1			oggStream
+	m	([BII)I	m_1114472		readPcm
+		p	1			buffer
+		p	2			offset
+		p	3			length
+	m	()Lnet/minecraft/unmapped/C_8423483;	m_0842369		getNextAudioPacket
+c	net/minecraft/unmapped/C_1133045		de/jarnbjo/vorbis/Mapping0
+	f	[I	f_5045799		magnitudes
+	f	[I	f_2332401		angles
+	f	[I	f_9277376		mux
+	f	[I	f_5258898		submapFloors
+	f	[I	f_5326611		submapResidues
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
+		p	1			vorbis
+		p	2			source
+		p	3			header
 	m	()[I	m_2841721		m_2841721
 	m	()[I	m_2863832		m_2863832
 	m	()[I	m_7804114		m_7804114
@@ -2944,109 +2944,109 @@ c	net/minecraft/unmapped/C_1655833		net/minecraft/client/ClientPlayerInteraction
 	m	()Z	m_4103218		hasStatusBars
 	m	(Lcom/mojang/minecraft/player/Player;)V	m_5484011		adjustPlayer
 		p	1			player
-c	net/minecraft/unmapped/C_1695696		net/minecraft/unmapped/C_1695696
-	f	I	f_5029809		f_5029809
-	f	I	f_1898525		f_1898525
-	f	[Lnet/minecraft/unmapped/C_5664626;	f_0767428		f_0767428
-	f	Lnet/minecraft/unmapped/C_5664626;	f_2740084		f_2740084
-	f	[[I	f_5888345		f_5888345
-	f	I	f_3889701		f_3889701
-	f	[[I	f_1189336		f_1189336
+c	net/minecraft/unmapped/C_1695696		de/jarnbjo/vorbis/Look
+	f	I	f_5029809		parts
+	f	I	f_1898525		stages
+	f	[Lnet/minecraft/unmapped/C_5664626;	f_0767428		fullbooks
+	f	Lnet/minecraft/unmapped/C_5664626;	f_2740084		phrasebook
+	f	[[I	f_5888345		partbooks
+	f	I	f_3889701		partvals
+	f	[[I	f_1189336		decodemap
 	m	(Lnet/minecraft/unmapped/C_0091050;Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_2214843;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-c	net/minecraft/unmapped/C_1703365		net/minecraft/unmapped/C_1703365
-	f	I	f_6371034		f_6371034
-	f	I	f_7347698		f_7347698
-	f	I	f_1132189		f_1132189
-	f	I	f_1663762		f_1663762
-	f	[Lnet/minecraft/unmapped/C_5718344;	f_6370242		f_6370242
+		p	1			residue
+		p	2			source
+		p	3			mode
+c	net/minecraft/unmapped/C_1703365		de/jarnbjo/vorbis/IdentificationHeader
+	f	I	f_6371034		channels
+	f	I	f_7347698		sampleRate
+	f	I	f_1132189		blockSize0
+	f	I	f_1663762		blockSize1
+	f	[Lnet/minecraft/unmapped/C_5718344;	f_6370242		mdct
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>		<init>
-		p	1			p_1
-c	net/minecraft/unmapped/C_1861953		net/minecraft/unmapped/C_1861953
-	f	Z	f_0834666		f_0834666
-	f	Z	f_9190175		f_9190175
-	f	I	f_5891998		f_5891998
-	f	[I	f_1723045		f_1723045
-	f	[I	f_6144659		f_6144659
-	f	I	f_8776241		f_8776241
-	f	[B	f_8033651		f_8033651
-	f	[B	f_7534420		f_7534420
+		p	1			source
+c	net/minecraft/unmapped/C_1861953		de/jarnbjo/ogg/OggPage
+	f	Z	f_0834666		continued
+	f	Z	f_9190175		eos
+	f	I	f_5891998		streamSerialNumber
+	f	[I	f_1723045		segmentOffsets
+	f	[I	f_6144659		segmentLengths
+	f	I	f_8776241		totalLength
+	f	[B	f_8033651		segmentTable
+	f	[B	f_7534420		data
 	m	()V	<init>		<init>
 	m	(ZZZJIII[I[II[B[B[B)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
+		p	2			bos
 		p	3			p_3
-		p	4			p_4
+		p	4			absoluteGranulePosition
 		p	6			p_6
-		p	7			p_7
-		p	8			p_8
+		p	7			pageSequenceNumber
+		p	8			pageCheckSum
 		p	9			p_9
 		p	10			p_10
 		p	11			p_11
-		p	12			p_12
+		p	12			header
 		p	13			p_13
 		p	14			p_14
-	m	(Ljava/io/InputStream;)Lnet/minecraft/unmapped/C_1861953;	m_8807495		m_8807495
-		p	0			p_0
-	m	(Ljava/lang/Object;Z)Lnet/minecraft/unmapped/C_1861953;	m_6142753		m_6142753
-		p	0			p_0
-		p	1			p_1
-	m	(Ljava/io/InputStream;[B)V	m_3333673		m_3333673
-		p	0			p_0
-		p	1			p_1
-	m	()I	m_4618783		m_4618783
+	m	(Ljava/io/InputStream;)Lnet/minecraft/unmapped/C_1861953;	m_8807495		create
+		p	0			source
+	m	(Ljava/lang/Object;Z)Lnet/minecraft/unmapped/C_1861953;	m_6142753		create
+		p	0			source
+		p	1			skipData
+	m	(Ljava/io/InputStream;[B)V	m_3333673		readFully
+		p	0			source
+		p	1			buffer
+	m	()I	m_4618783		getTotalLength
 c	net/minecraft/unmapped/C_1996769		net/minecraft/unmapped/C_1996769
 	m	([I[II)Z	m_6552350		m_6552350
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
-c	net/minecraft/unmapped/C_2122471		net/minecraft/unmapped/C_2122471
+c	net/minecraft/unmapped/C_2122471		de/jarnbjo/vorbis/Util
 	m	()V	<init>		<init>
-	m	(I)I	m_3224692		m_3224692
-		p	0			p_0
-	m	(I)F	m_7418927		m_7418927
-		p	0			p_0
-	m	([II)I	m_9852234		m_9852234
-		p	0			p_0
-		p	1			p_1
-	m	([II)I	m_4551640		m_4551640
-		p	0			p_0
-		p	1			p_1
-	m	(IIII[F)V	m_6040209		m_6040209
-		p	0			p_0
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-c	net/minecraft/unmapped/C_2214843		net/minecraft/unmapped/C_2214843
-	f	Z	f_3877404		f_3877404
-	f	I	f_9134511		f_9134511
-	f	I	f_8453625		f_8453625
-	f	I	f_5472480		f_5472480
+	m	(I)I	m_3224692		ilog
+		p	0			x
+	m	(I)F	m_7418927		float32unpack
+		p	0			x
+	m	([II)I	m_9852234		lowNeighbour
+		p	0			v
+		p	1			x
+	m	([II)I	m_4551640		highNeighbour
+		p	0			v
+		p	1			x
+	m	(IIII[F)V	m_6040209		renderLine
+		p	0			x0
+		p	1			y0
+		p	2			x1
+		p	3			y1
+		p	4			v
+c	net/minecraft/unmapped/C_2214843		de/jarnbjo/vorbis/Mode
+	f	Z	f_3877404		blockFlag
+	f	I	f_9134511		windowType
+	f	I	f_8453625		transformType
+	f	I	f_5472480		mapping
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-c	net/minecraft/unmapped/C_2480088		net/minecraft/unmapped/C_2480088
-	f	Ljava/net/URLConnection;	f_9549861		f_9549861
-	f	Ljava/io/InputStream;	f_1819751		f_1819751
-	f	I	f_1922040		f_1922040
-	f	Ljava/util/HashMap;	f_6328291		f_6328291
-	f	Lnet/minecraft/unmapped/C_1861953;	f_5203731		f_5203731
+		p	1			source
+		p	2			header
+c	net/minecraft/unmapped/C_2480088		de/jarnbjo/ogg/OnDemandUrlStream
+	f	Ljava/net/URLConnection;	f_9549861		source
+	f	Ljava/io/InputStream;	f_1819751		sourceStream
+	f	I	f_1922040		position
+	f	Ljava/util/HashMap;	f_6328291		logicalStreams
+	f	Lnet/minecraft/unmapped/C_1861953;	f_5203731		firstPage
 	m	(Ljava/net/URL;)V	<init>		<init>
-		p	1			p_1
-	m	()Lnet/minecraft/unmapped/C_1861953;	m_1806708		m_1806708
+		p	1			source
+	m	()Lnet/minecraft/unmapped/C_1861953;	m_1806708		getOggPage
 c	net/minecraft/unmapped/C_2964760		net/minecraft/unmapped/C_2964760
 	m	(II)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
 	m	()I	m_1206777		m_1206777
-c	net/minecraft/unmapped/C_3160234		net/minecraft/unmapped/C_3160234
-	f	[I	f_7127257		f_7127257
+c	net/minecraft/unmapped/C_3160234		de/jarnbjo/vorbis/Floor0
+	f	[I	f_7127257		bookList
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
+		p	1			source
+		p	2			header
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155		m_5036155
 		p	1			p_1
 		p	2			p_2
@@ -3138,7 +3138,7 @@ c	net/minecraft/unmapped/C_4304615		net/minecraft/unmapped/C_4304615
 		p	6			p_6
 c	net/minecraft/unmapped/C_4632560		net/minecraft/unmapped/C_4632560
 	m	()V	<init>		<init>
-c	net/minecraft/unmapped/C_4811676		net/minecraft/unmapped/C_4811676
+c	net/minecraft/unmapped/C_4811676		de/jarnbjo/vorbis/Residue2
 	m	()V	<init>		<init>
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
 		p	1			p_1
@@ -3150,16 +3150,16 @@ c	net/minecraft/unmapped/C_4811676		net/minecraft/unmapped/C_4811676
 		p	4			p_4
 		p	5			p_5
 	m	()Ljava/lang/Object;	clone		clone
-c	net/minecraft/unmapped/C_4958210		net/minecraft/unmapped/C_4958210
+c	net/minecraft/unmapped/C_4958210		de/jarnbjo/ogg/LogicalOggStreamImpl
 	f	Lnet/minecraft/unmapped/C_2480088;	f_9154799		f_9154799
-	f	Ljava/util/ArrayList;	f_2795626		f_2795626
-	f	I	f_4763122		f_4763122
-	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523		f_4426523
-	f	I	f_6597740		f_6597740
+	f	Ljava/util/ArrayList;	f_2795626		pageNumberMapping
+	f	I	f_4763122		pageIndex
+	f	Lnet/minecraft/unmapped/C_1861953;	f_4426523		currentPage
+	f	I	f_6597740		currentSegmentIndex
 	m	(Lnet/minecraft/unmapped/C_2480088;)V	<init>		<init>
-		p	1			p_1
-	m	()Lnet/minecraft/unmapped/C_1861953;	m_0516762		m_0516762
-	m	()[B	m_0642862		m_0642862
+		p	1			source
+	m	()Lnet/minecraft/unmapped/C_1861953;	m_0516762		getNextOggPage
+	m	()[B	m_0642862		getNextOggPacket
 c	net/minecraft/unmapped/C_5044387		net/minecraft/client/SurvivalInteractionManager
 	f	I	f_6685687		targetBlockX
 	f	I	f_0412535		targetBlockY
@@ -3214,60 +3214,60 @@ c	net/minecraft/unmapped/C_5169041		net/minecraft/unmapped/C_5169041
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3
-c	net/minecraft/unmapped/C_5664626		net/minecraft/unmapped/C_5664626
-	f	Lnet/minecraft/unmapped/C_8560236;	f_2040146		f_2040146
-	f	I	f_4766759		f_4766759
-	f	I	f_1959361		f_1959361
-	f	[I	f_2090137		f_2090137
-	f	[[F	f_7452409		f_7452409
+c	net/minecraft/unmapped/C_5664626		de/jarnbjo/vorbis/CodeBook
+	f	Lnet/minecraft/unmapped/C_8560236;	f_2040146		huffmanRoot
+	f	I	f_4766759		dimensions
+	f	I	f_1959361		entries
+	f	[I	f_2090137		entryLengths
+	f	[[F	f_7452409		valueVector
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>		<init>
-		p	1			p_1
-	m	([I)Z	m_8448942		m_8448942
-		p	1			p_1
-c	net/minecraft/unmapped/C_5718344		net/minecraft/unmapped/C_5718344
+		p	1			source
+	m	([I)Z	m_8448942		createHuffmanTree
+		p	1			entryLengths
+c	net/minecraft/unmapped/C_5718344		de/jarnbjo/vorbis/MdctFloat
 	f	I	f_3569804		f_3569804
-	f	I	f_7581426		f_7581426
-	f	[F	f_4416437		f_4416437
-	f	[I	f_3575069		f_3575069
-	f	F	f_1570944		f_1570944
-	f	F	f_5352698		f_5352698
-	f	F	f_8288566		f_8288566
-	f	F	f_7365864		f_7365864
-	f	[F	f_8917175		f_8917175
-	f	[F	f_1386816		f_1386816
+	f	I	f_7581426		log2n
+	f	[F	f_4416437		trig
+	f	[I	f_3575069		bitrev
+	f	F	f_1570944		dtmp1
+	f	F	f_5352698		dtmp2
+	f	F	f_8288566		dtmp3
+	f	F	f_7365864		dtmp4
+	f	[F	f_8917175		_x
+	f	[F	f_1386816		_w
 	m	(I)V	<init>		<init>
-		p	1			p_1
-	m	([F[F[I)V	m_4904561		m_4904561
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-c	net/minecraft/unmapped/C_5753145		net/minecraft/unmapped/C_5753145
-	f	[Lnet/minecraft/unmapped/C_5664626;	f_8744428		f_8744428
-	f	[Lnet/minecraft/unmapped/C_6848444;	f_1545784		f_1545784
-	f	[Lnet/minecraft/unmapped/C_0091050;	f_4340403		f_4340403
-	f	[Lnet/minecraft/unmapped/C_6908252;	f_0234341		f_0234341
-	f	[Lnet/minecraft/unmapped/C_2214843;	f_1933102		f_1933102
+		p	1			n
+	m	([F[F[I)V	m_4904561		imdct
+		p	1			frq
+		p	2			window
+		p	3			pcm
+c	net/minecraft/unmapped/C_5753145		de/jarnbjo/vorbis/SetupHeader
+	f	[Lnet/minecraft/unmapped/C_5664626;	f_8744428		codeBooks
+	f	[Lnet/minecraft/unmapped/C_6848444;	f_1545784		floors
+	f	[Lnet/minecraft/unmapped/C_0091050;	f_4340403		residues
+	f	[Lnet/minecraft/unmapped/C_6908252;	f_0234341		mappings
+	f	[Lnet/minecraft/unmapped/C_2214843;	f_1933102		modes
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-c	net/minecraft/unmapped/C_5765318		net/minecraft/unmapped/C_5765318
-	f	[I	f_4591976		f_4591976
-	f	I	f_4755198		f_4755198
-	f	I	f_0970456		f_0970456
-	f	I	f_2129899		f_2129899
-	f	[I	f_9096800		f_9096800
-	f	[I	f_2726755		f_2726755
-	f	[I	f_4057153		f_4057153
-	f	[[I	f_3838360		f_3838360
-	f	[I	f_3686218		f_3686218
-	f	[I	f_3253636		f_3253636
-	f	[I	f_7690103		f_7690103
-	f	[I	f_7973024		f_7973024
-	f	[I	f_1202498		f_1202498
+		p	1			vorbis
+		p	2			source
+c	net/minecraft/unmapped/C_5765318		de/jarnbjo/vorbis/Floor1
+	f	[I	f_4591976		partitionClassList
+	f	I	f_4755198		maximumClass
+	f	I	f_0970456		multiplier
+	f	I	f_2129899		rangeBits
+	f	[I	f_9096800		classDimensions
+	f	[I	f_2726755		classSubclasses
+	f	[I	f_4057153		classMasterbooks
+	f	[[I	f_3838360		subclassBooks
+	f	[I	f_3686218		xList
+	f	[I	f_3253636		yList
+	f	[I	f_7690103		lowNeighbours
+	f	[I	f_7973024		highNeighbours
+	f	[I	f_1202498		RANGE
 	m	()V	<init>		<init>
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
+		p	1			source
+		p	2			header
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155		m_5036155
 		p	1			p_1
 		p	2			p_2
@@ -3316,17 +3316,17 @@ c	net/minecraft/unmapped/C_6786807		net/minecraft/unmapped/C_6786807
 		p	2			p_2
 	m	()F	m_4192289		m_4192289
 	m	()F	m_2230278		m_2230278
-c	net/minecraft/unmapped/C_6848444		net/minecraft/unmapped/C_6848444
-	f	[F	f_3370702		f_3370702
+c	net/minecraft/unmapped/C_6848444		de/jarnbjo/vorbis/Floor
+	f	[F	f_3370702		DB_STATIC_TABLE
 	m	()V	<init>		<init>
-	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6848444;	m_3831585		m_3831585
-		p	0			p_0
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155		m_5036155
-		p	1			p_1
-		p	2			p_2
-	m	([F)V	m_5525230		m_5525230
-		p	1			p_1
+	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6848444;	m_3831585		createInstance
+		p	0			source
+		p	1			header
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)Lnet/minecraft/unmapped/C_6848444;	m_5036155		decodeFloor
+		p	1			vorbis
+		p	2			source
+	m	([F)V	m_5525230		computeFloor
+		p	1			vector
 	m	()V	<clinit>		<clinit>
 c	net/minecraft/unmapped/C_6857610		net/minecraft/unmapped/C_6857610
 	f	[S	f_2102733		f_2102733
@@ -3334,19 +3334,19 @@ c	net/minecraft/unmapped/C_6857610		net/minecraft/unmapped/C_6857610
 	m	([SF)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
-c	net/minecraft/unmapped/C_6908252		net/minecraft/unmapped/C_6908252
+c	net/minecraft/unmapped/C_6908252		de/jarnbjo/vorbis/Mapping
 	m	()V	<init>		<init>
-	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6908252;	m_3513632		m_3513632
-		p	0			p_0
-		p	1			p_1
-		p	2			p_2
-	m	()[I	m_2841721		m_2841721
-	m	()[I	m_2863832		m_2863832
-	m	()[I	m_7804114		m_7804114
-	m	()[I	m_1912102		m_1912102
-	m	()[I	m_9055268		m_9055268
-	m	()I	m_9681215		m_9681215
-	m	()I	m_6247361		m_6247361
+	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)Lnet/minecraft/unmapped/C_6908252;	m_3513632		createInstance
+		p	0			vorbis
+		p	1			source
+		p	2			header
+	m	()[I	m_2841721		getAngles
+	m	()[I	m_2863832		getMagnitudes
+	m	()[I	m_7804114		getMux
+	m	()[I	m_1912102		getSubmapFloors
+	m	()[I	m_9055268		getSubmapResidues
+	m	()I	m_9681215		getCouplingSteps
+	m	()I	m_6247361		getSubmaps
 c	net/minecraft/unmapped/C_6975176		net/minecraft/unmapped/C_6975176
 	m	()F	m_4192289		m_4192289
 	m	()F	m_2230278		m_2230278
@@ -3479,57 +3479,57 @@ c	net/minecraft/unmapped/C_7898033		net/minecraft/client/render/model/entity/Mob
 		p	4			p_4
 		p	5			p_5
 		p	6			p_6
-c	net/minecraft/unmapped/C_7900390		net/minecraft/unmapped/C_7900390
-	f	[B	f_8612550		f_8612550
-	f	B	f_8992957		f_8992957
-	f	I	f_6974560		f_6974560
-	f	I	f_0175362		f_0175362
-	f	I	f_4670471		f_4670471
+c	net/minecraft/unmapped/C_7900390		de/jarnbjo/util/io/ByteArrayBitInputStream
+	f	[B	f_8612550		source
+	f	B	f_8992957		currentByte
+	f	I	f_6974560		endian
+	f	I	f_0175362		byteIndex
+	f	I	f_4670471		bitIndex
 	m	([B)V	<init>		<init>
-		p	1			p_1
+		p	1			source
 	m	([BI)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
-	m	()Z	m_0530593		m_0530593
-	m	(I)I	m_6085672		m_6085672
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_8560236;)I	m_1173636		m_1173636
-		p	1			p_1
-	m	(I)J	m_1016947		m_1016947
-		p	1			p_1
+		p	2			endian
+	m	()Z	m_0530593		getBit
+	m	(I)I	m_6085672		getInt
+		p	1			bits
+	m	(Lnet/minecraft/unmapped/C_8560236;)I	m_1173636		getInt
+		p	1			root
+	m	(I)J	m_1016947		getLong
+		p	1			bits
 c	net/minecraft/unmapped/C_8100347		net/minecraft/unmapped/C_8100347
 	f	Ljava/util/Set;	f_9798909		f_9798909
 	m	(Ljava/io/InputStream;)V	<init>		<init>
 		p	1			p_1
 	m	()Ljava/io/ObjectStreamClass;	readClassDescriptor		readClassDescriptor
-c	net/minecraft/unmapped/C_8423483		net/minecraft/unmapped/C_8423483
-	f	I	f_8907271		f_8907271
-	f	Lnet/minecraft/unmapped/C_2214843;	f_5727714		f_5727714
-	f	Lnet/minecraft/unmapped/C_6908252;	f_0002876		f_0002876
-	f	I	f_1372727		f_1372727
-	f	Z	f_4011038		f_4011038
-	f	Z	f_1507074		f_1507074
-	f	Z	f_2033670		f_2033670
-	f	I	f_4158073		f_4158073
-	f	I	f_1490965		f_1490965
-	f	I	f_9464818		f_9464818
-	f	I	f_8817007		f_8817007
-	f	I	f_3769840		f_3769840
-	f	I	f_2972950		f_2972950
-	f	[F	f_3299597		f_3299597
-	f	[[F	f_1316142		f_1316142
-	f	[[I	f_0021803		f_0021803
-	f	[Lnet/minecraft/unmapped/C_6848444;	f_0180198		f_0180198
-	f	[Z	f_8030818		f_8030818
-	f	[[F	f_3369714		f_3369714
+c	net/minecraft/unmapped/C_8423483		de/jarnbjo/vorbis/AudioPacket
+	f	I	f_8907271		modeNumber
+	f	Lnet/minecraft/unmapped/C_2214843;	f_5727714		mode
+	f	Lnet/minecraft/unmapped/C_6908252;	f_0002876		mapping
+	f	I	f_1372727		n
+	f	Z	f_4011038		blockFlag
+	f	Z	f_1507074		previousWindowFlag
+	f	Z	f_2033670		nextWindowFlag
+	f	I	f_4158073		windowCenter
+	f	I	f_1490965		leftWindowStart
+	f	I	f_9464818		leftWindowEnd
+	f	I	f_8817007		leftN
+	f	I	f_3769840		rightWindowStart
+	f	I	f_2972950		rightN
+	f	[F	f_3299597		window
+	f	[[F	f_1316142		pcm
+	f	[[I	f_0021803		pcmInt
+	f	[Lnet/minecraft/unmapped/C_6848444;	f_0180198		channelFloors
+	f	[Z	f_8030818		noResidues
+	f	[[F	f_3369714		windows
 	m	(Lnet/minecraft/unmapped/C_0322130;Lnet/minecraft/unmapped/C_7900390;)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-	m	()[F	m_4014882		m_4014882
-	m	()I	m_3048178		m_3048178
-	m	(Lnet/minecraft/unmapped/C_8423483;[B)V	m_4451826		m_4451826
-		p	1			p_1
-		p	2			p_2
+		p	1			vorbis
+		p	2			source
+	m	()[F	m_4014882		getComputedWindow
+	m	()I	m_3048178		getNumberOfSamples
+	m	(Lnet/minecraft/unmapped/C_8423483;[B)V	m_4451826		getPcm
+		p	1			previousPacket
+		p	2			buffer
 	m	()V	<clinit>		<clinit>
 c	net/minecraft/unmapped/C_8534347		net/minecraft/unmapped/C_8534347
 	f	Z	f_3030770		f_3030770
@@ -3544,28 +3544,28 @@ c	net/minecraft/unmapped/C_8534347		net/minecraft/unmapped/C_8534347
 		p	1			p_1
 		p	2			p_2
 	m	()V	run		run
-c	net/minecraft/unmapped/C_8560236		net/minecraft/unmapped/C_8560236
-	f	I	f_7958293		f_7958293
-	f	Lnet/minecraft/unmapped/C_8560236;	f_9200603		f_9200603
-	f	Lnet/minecraft/unmapped/C_8560236;	f_6180971		f_6180971
-	f	Ljava/lang/Integer;	f_1829393		f_1829393
-	f	Z	f_4791979		f_4791979
+c	net/minecraft/unmapped/C_8560236		de/jarnbjo/util/io/HuffmanNode
+	f	I	f_7958293		depth
+	f	Lnet/minecraft/unmapped/C_8560236;	f_9200603		o0
+	f	Lnet/minecraft/unmapped/C_8560236;	f_6180971		o1
+	f	Ljava/lang/Integer;	f_1829393		value
+	f	Z	f_4791979		full
 	m	()V	<init>		<init>
 	m	(Lnet/minecraft/unmapped/C_8560236;)V	<init>		<init>
-		p	1			p_1
+		p	1			parent
 	m	(Lnet/minecraft/unmapped/C_8560236;I)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
-	m	()Z	m_0477567		m_0477567
-	m	(II)Z	m_3923716		m_3923716
-		p	1			p_1
+	m	()Z	m_0477567		isFull
+	m	(II)Z	m_3923716		setNewValue
+		p	1			depth
 		p	2			p_2
-c	net/minecraft/unmapped/C_8903842		net/minecraft/unmapped/C_8903842
-	f	Ljava/util/HashMap;	f_6719370		f_6719370
+c	net/minecraft/unmapped/C_8903842		de/jarnbjo/vorbis/CommentHeader
+	f	Ljava/util/HashMap;	f_6719370		comments
 	m	(Lnet/minecraft/unmapped/C_7900390;)V	<init>		<init>
-		p	1			p_1
-	m	(Lnet/minecraft/unmapped/C_7900390;)Ljava/lang/String;	m_1750090		m_1750090
-		p	0			p_0
+		p	1			source
+	m	(Lnet/minecraft/unmapped/C_7900390;)Ljava/lang/String;	m_1750090		getString
+		p	0			source
 c	net/minecraft/unmapped/C_8995754		net/minecraft/unmapped/C_8995754
 	f	Z	f_8629289		f_8629289
 	f	Ljava/nio/channels/SocketChannel;	f_6794126		f_6794126
@@ -3630,7 +3630,7 @@ c	net/minecraft/unmapped/C_9665058		net/minecraft/unmapped/C_9665058
 		p	1			p_1
 	m	(Ljava/io/InputStream;)[B	m_8590209		m_8590209
 		p	0			p_0
-c	net/minecraft/unmapped/C_9722514		net/minecraft/unmapped/C_9722514
+c	net/minecraft/unmapped/C_9722514		de/jarnbjo/vorbis/Residue0
 	m	(Lnet/minecraft/unmapped/C_7900390;Lnet/minecraft/unmapped/C_5753145;)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2

--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -16,7 +16,7 @@ c	net/minecraft/unmapped/C_0456473
 	m	(IIZ)V	<init>		<init>
 		p	1			p_1
 		p	2			p_2
-		p	3			p_3
+		p	3			culling
 	m	(Lcom/mojang/minecraft/level/Level;IIII)Z	m_8199947		m_8199947
 		p	1			p_1
 		p	2			p_2
@@ -109,11 +109,11 @@ c	net/minecraft/unmapped/C_1124552
 		p	3			p_3
 		p	4			p_4
 		p	5			p_5
-	m	(Lnet/minecraft/unmapped/C_2334550;FFF)V	m_3078875		m_3078875
+	m	(Lnet/minecraft/unmapped/C_2334550;FFF)V	m_3078875		render
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
+		p	2			x
+		p	3			y
+		p	4			z
 	m	(III)Lcom/mojang/minecraft/phys/AABB;	m_9650578		m_9650578
 		p	1			p_1
 		p	2			p_2
@@ -218,24 +218,24 @@ c	net/minecraft/unmapped/C_3635204
 	f	F	f_4279373	gravity	
 	f	Lnet/minecraft/unmapped/C_3635204;	f_7315821	LEAVES	
 	f	Ljava/util/Random;	f_0457756		RANDOM
-	f	[I	f_0375741		f_0375741
+	f	[I	f_0375741		BRIGHTNESS
 	f	Lnet/minecraft/unmapped/C_3635204;	f_5708490		STONE
 	f	Lnet/minecraft/unmapped/C_3635204;	f_6242213		DIRT
-	f	Lnet/minecraft/unmapped/C_3635204;	f_5091096		f_5091096
-	f	Lnet/minecraft/unmapped/C_3635204;	f_8866375		f_8866375
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1957938		f_1957938
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1788821		f_1788821
-	f	Lnet/minecraft/unmapped/C_3635204;	f_7230133		f_7230133
-	f	Lnet/minecraft/unmapped/C_3635204;	f_4107115		f_4107115
-	f	Lnet/minecraft/unmapped/C_3635204;	f_0069613		f_0069613
-	f	Lnet/minecraft/unmapped/C_3635204;	f_4511668		f_4511668
-	f	Lnet/minecraft/unmapped/C_3635204;	f_3504882		f_3504882
-	f	Lnet/minecraft/unmapped/C_3635204;	f_1899131		f_1899131
+	f	Lnet/minecraft/unmapped/C_3635204;	f_5091096		COBBLESTONE
+	f	Lnet/minecraft/unmapped/C_3635204;	f_8866375		SAPLING
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1957938		WATER
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1788821		LAVA
+	f	Lnet/minecraft/unmapped/C_3635204;	f_7230133		GOLD_ORE
+	f	Lnet/minecraft/unmapped/C_3635204;	f_4107115		IRON_ORE
+	f	Lnet/minecraft/unmapped/C_3635204;	f_0069613		COAL_ORE
+	f	Lnet/minecraft/unmapped/C_3635204;	f_4511668		LEAVES
+	f	Lnet/minecraft/unmapped/C_3635204;	f_3504882		GOLD_BLOCK
+	f	Lnet/minecraft/unmapped/C_3635204;	f_1899131		IRON_BLOCK
 	f	Lnet/minecraft/unmapped/C_3635204;	f_3811921		TNT
-	f	Lnet/minecraft/unmapped/C_3635204;	f_9027845		f_9027845
-	f	Lnet/minecraft/unmapped/C_7120212;	f_3530839		f_3530839
+	f	Lnet/minecraft/unmapped/C_3635204;	f_9027845		OBSIDIAN
+	f	Lnet/minecraft/unmapped/C_7120212;	f_3530839		sound
 	f	Z	f_7253534		f_7253534
-	f	F	f_8697106		f_8697106
+	f	F	f_8697106		weight
 	m	(I)Lnet/minecraft/unmapped/C_3635204;	m_3669959	setOpacity	
 		c	Sets this block's light opacity.\n\n<p>\nNOTE: this method should only be used during the block's creation before it is registered.	
 		p	1		opacity	
@@ -308,13 +308,13 @@ c	net/minecraft/unmapped/C_3635204
 	m	(Lnet/minecraft/unmapped/C_3906126;F)V	m_5317075	dropItems	
 		p	1		world	
 		p	2		luck	
-	m	(Lnet/minecraft/unmapped/C_7120212;FFF)Lnet/minecraft/unmapped/C_3635204;	m_7659331		m_7659331
-		p	1			p_1
+	m	(Lnet/minecraft/unmapped/C_7120212;FFF)Lnet/minecraft/unmapped/C_3635204;	m_7659331		setProperties
+		p	1			sound
 		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-	m	(I)V	m_5930259		m_5930259
-		p	1			p_1
+		p	3			weight
+		p	4			hardness
+	m	(I)V	m_5930259		setBrightness
+		p	1			brightness
 	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_5198489		renderVertices
 		p	1			p_1
 	m	(Lcom/mojang/minecraft/level/Level;III)F	m_1598263		getBrightness
@@ -343,9 +343,9 @@ c	net/minecraft/unmapped/C_3635204
 		p	6			p_6
 	m	(Lnet/minecraft/unmapped/C_2334550;IIII)V	m_8901536		m_8901536
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
+		p	2			x
+		p	3			y
+		p	4			z
 		p	5			p_5
 	m	(III)Lcom/mojang/minecraft/phys/AABB;	m_5529828		getOutlineShape
 		p	1			x
@@ -364,18 +364,18 @@ c	net/minecraft/unmapped/C_3635204
 		p	4			z
 		p	5			random
 	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2454294;)V	m_3427045		addBreakParticles
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-	m	(Lcom/mojang/minecraft/level/Level;IIIILnet/minecraft/unmapped/C_2454294;)V	m_9622802		m_9622802
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-		p	6			p_6
+		p	1			world
+		p	2			x
+		p	3			y
+		p	4			z
+		p	5			particleManager
+	m	(Lcom/mojang/minecraft/level/Level;IIIILnet/minecraft/unmapped/C_2454294;)V	m_9622802		addDamageParticles
+		p	1			world
+		p	2			x
+		p	3			y
+		p	4			z
+		p	5			face
+		p	6			particleManager
 	m	(Lcom/mojang/minecraft/level/Level;IIII)V	m_9130741		neighborChanged
 		c		Performs a block update. This method is called when a neighboring block has updated\n(i.e. placed, broken, or otherwise changed state).
 		p	1			world
@@ -400,19 +400,19 @@ c	net/minecraft/unmapped/C_3635204
 		p	3			y
 		p	4			z
 	m	()I	m_6534436		getBaseDropCount
-	m	()I	m_1206777		m_1206777
+	m	()I	m_1206777		getDropItem
 	m	(Lcom/mojang/minecraft/level/Level;III)V	m_6201869		dropItems
 		p	1			level
 		p	2			x
 		p	3			y
 		p	4			z
 	m	(Lcom/mojang/minecraft/level/Level;IIIF)V	m_5317075		dropItems
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
-		p	5			p_5
-	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_3016343		m_3016343
+		p	1			world
+		p	2			x
+		p	3			y
+		p	4			z
+		p	5			chance
+	m	(Lnet/minecraft/unmapped/C_2334550;)V	m_3016343		render
 		p	1			p_1
 	m	()Z	m_3636937		m_3636937
 	m	(Lcom/mojang/minecraft/level/Level;III)V	m_5709385		onBroken
@@ -420,11 +420,11 @@ c	net/minecraft/unmapped/C_3635204
 		p	2			x
 		p	3			y
 		p	4			z
-	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2334550;)Z	m_7740877		m_7740877
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
+	m	(Lcom/mojang/minecraft/level/Level;IIILnet/minecraft/unmapped/C_2334550;)Z	m_7740877		render
+		p	1			world
+		p	2			x
+		p	3			y
+		p	4			z
 		p	5			p_5
 c	net/minecraft/unmapped/C_3724278
 	m	(Lnet/minecraft/unmapped/C_3906126;IIII)V	m_9130741	m_9130741	
@@ -438,7 +438,7 @@ c	net/minecraft/unmapped/C_3724278
 		p	2		p_2	
 		p	3		p_3	
 		p	4		p_4	
-	m	(Lnet/minecraft/unmapped/C_3906126;III)V	m_0416811	m_0416811	
+	m	(Lnet/minecraft/unmapped/C_3906126;III)V	m_0416811	tryFall	
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
@@ -454,11 +454,11 @@ c	net/minecraft/unmapped/C_3724278
 		p	3			p_3
 		p	4			p_4
 		p	5			p_5
-	m	(Lcom/mojang/minecraft/level/Level;III)V	m_0416811		m_0416811
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
-		p	4			p_4
+	m	(Lcom/mojang/minecraft/level/Level;III)V	m_0416811		tryFall
+		p	1			world
+		p	2			x
+		p	3			y
+		p	4			z
 c	net/minecraft/unmapped/C_3906126	net/minecraft/world/World	
 	f	Ljava/util/Random;	f_7114289	random	
 	f	[F	f_1283049	brightnessTable	
@@ -1000,7 +1000,7 @@ c	net/minecraft/unmapped/C_8241203	net/minecraft/block/DirtBlock
 	m	()V	<init>	<init>	
 c	net/minecraft/unmapped/C_8443484
 	f	Z	f_0425222	culling	
-	f	Z	f_1686264		f_1686264
+	f	Z	f_1686264		culling
 	m	(Lnet/minecraft/unmapped/C_3906126;IIII)Z	m_8199947	m_8199947	
 		p	1		p_1	
 		p	2		p_2	
@@ -1009,9 +1009,9 @@ c	net/minecraft/unmapped/C_8443484
 		p	5		p_5	
 	m	()V	<init>	<init>	
 	m	(IIZ)V	<init>		<init>
-		p	1			p_1
-		p	2			p_2
-		p	3			p_3
+		p	1			id
+		p	2			sprite
+		p	3			culling
 	m	(Lcom/mojang/minecraft/level/Level;IIII)Z	m_8199947		m_8199947
 		p	1			p_1
 		p	2			p_2

--- a/mappings/in-20091231-2255#in-20091223-1459.tinydiff
+++ b/mappings/in-20091231-2255#in-20091223-1459.tinydiff
@@ -152,9 +152,9 @@ c	net/minecraft/unmapped/C_9331929
 c	net/minecraft/client/Minecraft
 	f	Lnet/minecraft/unmapped/C_5367636;	f_5473933	player	
 	f	Lnet/minecraft/unmapped/C_5009044;	f_5473933		player
-	f	Z	f_7579809		f_7579809
-	f	Lorg/lwjgl/input/Cursor;	f_5333905		f_5333905
-	f	Ljava/awt/Robot;	f_9154570		f_9154570
+	f	Z	f_7579809		appletMode
+	f	Lorg/lwjgl/input/Cursor;	f_5333905		cursor
+	f	Ljava/awt/Robot;	f_9154570		robot
 c	net/minecraft/unmapped/C_0786431
 	m	()V	m_0844698	m_0844698	
 c	net/minecraft/unmapped/C_1044273
@@ -231,9 +231,9 @@ c	net/minecraft/unmapped/C_7542541
 		p	1		p_1	
 		p	2		p_2	
 		p	3		p_3	
-	m	(II)I	m_8154932		m_8154932
-		p	1			p_1
-		p	2			p_2
+	m	(II)I	m_8154932		findClosestSlot
+		p	1			mouseX
+		p	2			mouseY
 c	net/minecraft/unmapped/C_7542541$C_7192378	InventorySlot	
 	f	I	f_2513672	id	
 		c	The slot's index in its inventory	

--- a/mappings/in-20100104-2258#in-20091231-2255.tinydiff
+++ b/mappings/in-20100104-2258#in-20091231-2255.tinydiff
@@ -508,5 +508,5 @@ c	net/minecraft/unmapped/C_8425960
 		p	1		p_1	title
 	m	(Ljava/lang/String;)V	m_3915830	m_3915830	progressStage
 		p	1		p_1	stage
-	m	(I)V	m_1991224	m_1991224	progressStagePercentage
+	m	(I)V	m_1991224	m_1991224	progressPercentage
 		p	1		p_1	percentage

--- a/mappings/in-20100104-2258#in-20091231-2255.tinydiff
+++ b/mappings/in-20100104-2258#in-20091231-2255.tinydiff
@@ -508,5 +508,5 @@ c	net/minecraft/unmapped/C_8425960
 		p	1		p_1	title
 	m	(Ljava/lang/String;)V	m_3915830	m_3915830	progressStage
 		p	1		p_1	stage
-	m	(I)V	m_1991224	m_1991224	progressPercentage
+	m	(I)V	m_1991224	m_1991224	progressStagePercentage
 		p	1		p_1	percentage

--- a/mappings/in-20100110#in-20100104-2258.tinydiff
+++ b/mappings/in-20100110#in-20100104-2258.tinydiff
@@ -238,7 +238,7 @@ c	net/minecraft/client/Minecraft
 		p	3		type	
 		p	4		theme	
 	m	(I)V	m_6392526		createWorld
-		p	1			p_1
+		p	1			size
 c	net/minecraft/unmapped/C_0756314	net/minecraft/client/render/texture/WaterSprite	
 	f	[F	f_8838591	current	
 	f	[F	f_2397408	next	

--- a/mappings/in-20100110#in-20100104-2258.tinydiff
+++ b/mappings/in-20100110#in-20100104-2258.tinydiff
@@ -51,7 +51,7 @@ c	net/minecraft/unmapped/C_3724278
 		p	2			p_2
 		p	3			p_3
 		p	4			p_4
-	m	(Lnet/minecraft/unmapped/C_3906126;III)V	m_0416811		m_0416811
+	m	(Lnet/minecraft/unmapped/C_3906126;III)V	m_0416811		tryFall
 		p	1			p_1
 		p	2			p_2
 		p	3			p_3

--- a/mappings/in-20100124-2310#in-20100110.tinydiff
+++ b/mappings/in-20100124-2310#in-20100110.tinydiff
@@ -480,8 +480,8 @@ c	net/minecraft/client/Minecraft
 	m	(II)V	m_2180115	resize	
 		p	1		width	
 		p	2		height	
-	m	(Ljava/lang/String;)V	m_0572353		m_0572353
-		p	0			p_0
+	m	(Ljava/lang/String;)V	m_0572353		logGlError
+		p	0			message
 c	net/minecraft/unmapped/C_0823197	net/minecraft/client/entity/particle/ExplosionParticle	
 	m	(Lnet/minecraft/unmapped/C_2334550;FFFFFF)V	m_7521183	m_7521183	
 		p	1		p_1	
@@ -521,16 +521,16 @@ c	net/minecraft/unmapped/C_3466301
 		p	2		y	
 		p	3		z	
 c	net/minecraft/unmapped/C_3699792
-	f	I	f_0775750		f_0775750
-	f	I	f_8519063		f_8519063
+	f	I	f_0775750		width
+	f	I	f_8519063		height
 	m	(Lnet/minecraft/client/Minecraft;)V	<init>	<init>	
 		p	1		minecraft	
 	m	(F)V	m_0276783	render	
 		p	1		tickDelta	
 	m	(Lnet/minecraft/client/Minecraft;II)V	<init>		<init>
 		p	1			p_1
-		p	2			p_2
-		p	3			p_3
+		p	2			width
+		p	3			height
 	m	()V	m_0276783		render
 c	net/minecraft/unmapped/C_3911481	net/minecraft/client/entity/particle/SmokeParticle	
 	m	(Lnet/minecraft/unmapped/C_2334550;FFFFFF)V	m_7521183	m_7521183	

--- a/mappings/in-20100206-2103#in-20100202-2330.tinydiff
+++ b/mappings/in-20100206-2103#in-20100202-2330.tinydiff
@@ -573,8 +573,8 @@ c	net/minecraft/unmapped/C_0786431
 	m	()Z	m_6957805	isPauseScreen	
 	m	()V	m_4410675	drawBackgroundTexture	
 	m	(II)V	m_3426670		render
-		p	1			p_1
-		p	2			p_2
+		p	1			mouseX
+		p	2			mouseY
 c	net/minecraft/unmapped/C_1017062
 	m	(IIF)V	m_3426670	m_3426670	
 		p	1		p_1	
@@ -710,7 +710,7 @@ c	net/minecraft/unmapped/C_4643161
 c	net/minecraft/unmapped/C_4766485
 	f	I	f_5774068	boundPage	
 	f	Ljava/nio/IntBuffer;	f_2974032	pageBuffer	
-	f	Lnet/minecraft/unmapped/C_7688744;	f_9105384		f_9105384
+	f	Lnet/minecraft/unmapped/C_7688744;	f_9105384		options
 c	net/minecraft/unmapped/C_5027796	net/minecraft/client/render/entity/GiantRenderer	
 	f	F	f_1676262	scale	
 	m	(Lnet/minecraft/unmapped/C_3239917;FF)V	<init>	<init>	

--- a/mappings/inf-20100227-1433#in-20100223.tinydiff
+++ b/mappings/inf-20100227-1433#in-20100223.tinydiff
@@ -1333,7 +1333,7 @@ c	net/minecraft/unmapped/C_1044273
 		p	3		tickDelta	
 	m	(Lnet/minecraft/unmapped/C_6516244;)V	m_4361284	cullChunks	
 		p	1		culler	
-	m	()V	m_8889498		m_8889498
+	m	()V	m_8889498		reload
 	m	(Lnet/minecraft/unmapped/C_0336319;Lnet/minecraft/unmapped/C_9265122;F)V	m_1380727		renderEntities
 		p	1			cameraPos
 		p	2			culler

--- a/mappings/inf-20100313#inf-20100227-1433.tinydiff
+++ b/mappings/inf-20100313#inf-20100227-1433.tinydiff
@@ -257,9 +257,9 @@ c	net/minecraft/unmapped/C_1044273
 	f	I	f_2346662	maxChunkY	
 	f	I	f_0381341	lastViewDistance	
 	f	Ljava/util/List;	f_0391517	chunksInCurrentLayer	
-	f	I	f_0437423		f_0437423
+	f	I	f_0437423		environmentGlLists
 	f	Ljava/nio/IntBuffer;	f_2125993		lastLayer
-	f	[I	f_6069347		f_6069347
+	f	[I	f_6069347		chunkLists
 	m	()V	m_4374098	reload	
 	m	(III)V	m_9346630	sortChunks	
 		p	1		cameraX	
@@ -462,8 +462,8 @@ c	net/minecraft/unmapped/C_5283200
 	m	(Lnet/minecraft/unmapped/C_1013763;)F	m_9608130		squaredDistanceToCenter
 		p	1			camera
 	m	([III)I	m_8783499		getGlList
-		p	1			p_1
-		p	2			p_2
+		p	1			glLists
+		p	2			offset
 		p	3			layer
 c	net/minecraft/unmapped/C_6516244
 	f	D	f_1603874	offsetX	

--- a/mappings/rd-160052-launcher#rd-132328-launcher.tinydiff
+++ b/mappings/rd-160052-launcher#rd-132328-launcher.tinydiff
@@ -1,5 +1,5 @@
 tiny	2	0
-c	net/minecraft/unmapped/C_0351020	net/minecraft/block/StoneBlock	
+c	net/minecraft/unmapped/C_0351020	net/minecraft/block/DirtBlock	
 	m	(II)V	<init>	<init>	
 		p	1		id	
 		p	2		sprite	


### PR DESCRIPTION
- maps entirety of networking, sound, `Minecraft` and some of other client stuff in 0.30-c
- fixes `Block.DIRT` being `StoneBlock` in classic