### PR TITLE
make BlockMap names consistent

### DIFF
--- a/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
+++ b/mappings/in-20091223-1459#c0.30-c-renew.tinydiff
@@ -1615,9 +1615,9 @@ c	net/minecraft/unmapped/C_5540851$9701047		9701047
 		p	1			p_1
 	m	()V	run		run
 c	net/minecraft/unmapped/C_4838406	net/minecraft/world/BlockMap	
-	f	I	f_8576289	width	
-	f	I	f_8277311	depth	
-	f	I	f_7001699	height	
+	f	I	f_8576289	sizeX	
+	f	I	f_8277311	sizeY	
+	f	I	f_7001699	sizeZ	
 	f	Lnet/minecraft/unmapped/C_4838406$C_2072059;	f_2657781	slot	
 	f	Lnet/minecraft/unmapped/C_4838406$C_2072059;	f_1292325	slot2	
 	f	[Ljava/util/List;	f_3779159	entityGrid	
@@ -1631,9 +1631,9 @@ c	net/minecraft/unmapped/C_4838406	net/minecraft/world/BlockMap
 		p	1		exclude	
 		p	2		bounds	
 c	net/minecraft/unmapped/C_4838406$C_2072059	Slot	
-	f	I	f_5609989	xSlot	
-	f	I	f_0579241	ySlot	
-	f	I	f_9357387	zSlot	
+	f	I	f_5609989	slotX	
+	f	I	f_0579241	slotY	
+	f	I	f_9357387	slotZ	
 	f	Lnet/minecraft/unmapped/C_4838406;	f_3119793	f_3119793	
 	m	(Lnet/minecraft/unmapped/C_4838406;)V	<init>	<init>	
 		p	1		p_1	

--- a/mappings/inf-20100316#inf-20100313.tinydiff
+++ b/mappings/inf-20100316#inf-20100313.tinydiff
@@ -163,9 +163,9 @@ c	net/minecraft/unmapped/C_9610577
 c	net/minecraft/unmapped/C_9232749
 	m	()V	m_2968224	notifyAmbientDarknessChanged	
 c	net/minecraft/unmapped/C_4838406		net/minecraft/world/BlockMap
-	f	I	f_8576289		width
-	f	I	f_8277311		depth
-	f	I	f_7001699		height
+	f	I	f_8576289		sizeX
+	f	I	f_8277311		sizeY
+	f	I	f_7001699		sizeZ
 	f	Lnet/minecraft/unmapped/C_4838406$C_2072059;	f_2657781		slot
 	f	Lnet/minecraft/unmapped/C_4838406$C_2072059;	f_1292325		slot2
 	f	[Ljava/util/List;	f_3779159		entityGrid
@@ -178,9 +178,9 @@ c	net/minecraft/unmapped/C_4838406		net/minecraft/world/BlockMap
 		p	1			exclude
 		p	2			bounds
 c	net/minecraft/unmapped/C_4838406$C_2072059		Slot
-	f	I	f_5609989		xSlot
-	f	I	f_0579241		ySlot
-	f	I	f_9357387		zSlot
+	f	I	f_5609989		slotX
+	f	I	f_0579241		slotY
+	f	I	f_9357387		slotZ
 	f	Lnet/minecraft/unmapped/C_4838406;	f_3119793		f_3119793
 	m	(Lnet/minecraft/unmapped/C_4838406;B)V	<init>		<init>
 		p	1			p_1


### PR DESCRIPTION
makes BlockMap names consistent with mappings:
`width`, `height`, `depth` -> `sizeX`, `sizeY`, `sizeZ`;
`xSlot`, `ySlot`, `zSlot` -> `slotX`, `slotY`, `slotZ`.