### PR TITLE
fix LiquidPocketFeature inverted boolean name

### DIFF
--- a/mappings/1.6.2#13w36a-1234.tinydiff
+++ b/mappings/1.6.2#13w36a-1234.tinydiff
@@ -6915,7 +6915,7 @@ c	net/minecraft/unmapped/C_16410909
 		p	2		canBeExposedToAir	
 	m	(Lnet/minecraft/unmapped/C_81592558;Z)V	<init>		<init>
 		p	1			liquid
-		p	2			canBeExposedToAir
+		p	2			avoidAir
 c	net/minecraft/unmapped/C_39524089
 	m	()Ljava/util/Set;	m_71903807		keySet
 c	net/minecraft/unmapped/C_41649100

--- a/mappings/1.6.3#13w37b.tinydiff
+++ b/mappings/1.6.3#13w37b.tinydiff
@@ -7548,7 +7548,7 @@ c	net/minecraft/unmapped/C_16410909
 		p	2		canBeExposedToAir	
 	m	(Lnet/minecraft/unmapped/C_81592558;Z)V	<init>		<init>
 		p	1			liquid
-		p	2			canBeExposedToAir
+		p	2			avoidAir
 c	net/minecraft/unmapped/C_39524089
 	m	()Ljava/util/Set;	m_71903807		keySet
 c	net/minecraft/unmapped/C_41649100

--- a/mappings/1.7.10#14w28b.tinydiff
+++ b/mappings/1.7.10#14w28b.tinydiff
@@ -13600,8 +13600,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_64041439;J)V	<init>	<init>	

--- a/mappings/1.7.5#14w05a.tinydiff
+++ b/mappings/1.7.5#14w05a.tinydiff
@@ -9780,8 +9780,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.6#1.8.1-pre1.tinydiff
+++ b/mappings/1.7.6#1.8.1-pre1.tinydiff
@@ -14616,8 +14616,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_64041439;J)V	<init>	<init>	

--- a/mappings/1.7.6#14w04a-1526.tinydiff
+++ b/mappings/1.7.6#14w04a-1526.tinydiff
@@ -8428,8 +8428,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.6#14w07a.tinydiff
+++ b/mappings/1.7.6#14w07a.tinydiff
@@ -10008,8 +10008,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.6#14w11a.tinydiff
+++ b/mappings/1.7.6#14w11a.tinydiff
@@ -10375,8 +10375,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.8#1.8.1-pre2.tinydiff
+++ b/mappings/1.7.8#1.8.1-pre2.tinydiff
@@ -14586,8 +14586,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_64041439;J)V	<init>	<init>	

--- a/mappings/1.7.8#14w10a.tinydiff
+++ b/mappings/1.7.8#14w10a.tinydiff
@@ -10066,8 +10066,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.8#14w17a.tinydiff
+++ b/mappings/1.7.8#14w17a.tinydiff
@@ -10921,8 +10921,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.8#14w25a.tinydiff
+++ b/mappings/1.7.8#14w25a.tinydiff
@@ -12778,8 +12778,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_70943525;III)Ljava/util/List;	m_07648116	m_07648116	

--- a/mappings/1.7.8#14w28b.tinydiff
+++ b/mappings/1.7.8#14w28b.tinydiff
@@ -13608,8 +13608,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 	m	(Lnet/minecraft/unmapped/C_64041439;J)V	<init>	<init>	

--- a/mappings/13w01b#13w02a.tinydiff
+++ b/mappings/13w01b#13w02a.tinydiff
@@ -2397,7 +2397,7 @@ c	net/minecraft/unmapped/C_87525310
 	m	(Lnet/minecraft/unmapped/C_97491075;)V	m_09377185		m_09377185
 		p	1			p_1
 c	net/minecraft/unmapped/C_16410909
-	f	Z	f_94551919		canBeExposedToAir
+	f	Z	f_94551919		avoidAir
 	m	(I)V	<init>	<init>	
 		p	1		p_1	
 	m	(IZ)V	<init>		<init>

--- a/mappings/14w02c#14w03a.tinydiff
+++ b/mappings/14w02c#14w03a.tinydiff
@@ -252,8 +252,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830		upsideDownGlowstoneCluster
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842		glowstoneCluster
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651		quartzOreVein
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		exposedLavaPocket
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		lavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960		enclosedLavaPocket
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790		exposableLavaPocket
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715		brownMushroom
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529		redMushroom
 c	net/minecraft/unmapped/C_99795455

--- a/mappings/18w05a#18w06a.tinydiff
+++ b/mappings/18w05a#18w06a.tinydiff
@@ -2790,8 +2790,8 @@ c	net/minecraft/unmapped/C_99454192
 	f	Lnet/minecraft/unmapped/C_83169823;	f_59790830	upsideDownGlowstoneCluster	
 	f	Lnet/minecraft/unmapped/C_24812991;	f_24573842	glowstoneCluster	
 	f	Lnet/minecraft/unmapped/C_30339133;	f_92189651	quartzOreVein	
-	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960	exposedLavaPocket	
-	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790	lavaPocket	
+	f	Lnet/minecraft/unmapped/C_16410909;	f_32266960	enclosedLavaPocket	
+	f	Lnet/minecraft/unmapped/C_16410909;	f_10949790	exposableLavaPocket	
 	f	Lnet/minecraft/unmapped/C_83322766;	f_03687715	brownMushroom	
 	f	Lnet/minecraft/unmapped/C_83322766;	f_53574529	redMushroom	
 	f	Lnet/minecraft/unmapped/C_30339133;	f_80674155	magmaVein	
@@ -6423,11 +6423,11 @@ c	net/minecraft/unmapped/C_48996137	net/minecraft/world/gen/chunk/FlatWorldGener
 	m	()[Lnet/minecraft/unmapped/C_15815210;	m_13783896		getBlocks
 	m	()V	<clinit>		<clinit>
 c	net/minecraft/unmapped/C_16410909
-	f	Z	f_94551919	canBeExposedToAir	
+	f	Z	f_94551919	avoidAir	
 	f	Lnet/minecraft/unmapped/C_81592558;	f_10494660	liquid	
 	m	(Lnet/minecraft/unmapped/C_81592558;Z)V	<init>	<init>	
 		p	1		liquid	
-		p	2		canBeExposedToAir	
+		p	2		avoidAir	
 	m	(Lnet/minecraft/unmapped/C_64041439;Ljava/util/Random;Lnet/minecraft/unmapped/C_32594356;)Z	m_85015587	m_85015587	
 		p	1		p_1	
 		p	2		p_2	


### PR DESCRIPTION
The `canBeExposedToAir` boolean name is inverted, changed to `avoidAir` to match the 1.13.1 name.

`exposableLavaPocket` can either be exposed to air _or_ enclosed, `enclosedLavaPocket` _must_ be enclosed in netherrack on all sides. Does this fit the naming convention?
