### PR TITLE
fix Camera buffer names

### DIFF
--- a/mappings/1.0.0#1.0.1.tinydiff
+++ b/mappings/1.0.0#1.0.1.tinydiff
@@ -8940,9 +8940,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/1.0.0-rc1#1.0.0-rc2-1656.tinydiff
+++ b/mappings/1.0.0-rc1#1.0.0-rc2-1656.tinydiff
@@ -1668,9 +1668,9 @@ c	net/minecraft/unmapped/C_93577926		net/minecraft/client/render/Camera
 	f	F	f_14820533		x
 	f	F	f_79596197		y
 	f	F	f_50356219		z
-	f	Ljava/nio/IntBuffer;	f_19076117		glIntBuffer
-	f	Ljava/nio/FloatBuffer;	f_67310505		glFloatBuffer1
-	f	Ljava/nio/FloatBuffer;	f_04121695		glFloatBuffer2
+	f	Ljava/nio/IntBuffer;	f_19076117		VIEWPORT_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_67310505		MODELVIEW_MATRIX_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_04121695		PROJECTION_MATRIX_BUFFER
 	f	Ljava/nio/FloatBuffer;	f_17323686		POSITION_BUFFER
 	f	F	f_01695376		dx
 	f	F	f_00169964		dy

--- a/mappings/1.0.1#11w47a.tinydiff
+++ b/mappings/1.0.1#11w47a.tinydiff
@@ -8517,9 +8517,9 @@ c	net/minecraft/unmapped/C_93577926		net/minecraft/client/render/Camera
 	f	F	f_14820533		x
 	f	F	f_79596197		y
 	f	F	f_50356219		z
-	f	Ljava/nio/IntBuffer;	f_19076117		glIntBuffer
-	f	Ljava/nio/FloatBuffer;	f_67310505		glFloatBuffer1
-	f	Ljava/nio/FloatBuffer;	f_04121695		glFloatBuffer2
+	f	Ljava/nio/IntBuffer;	f_19076117		VIEWPORT_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_67310505		MODELVIEW_MATRIX_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_04121695		PROJECTION_MATRIX_BUFFER
 	f	Ljava/nio/FloatBuffer;	f_17323686		POSITION_BUFFER
 	f	F	f_01695376		dx
 	f	F	f_00169964		dy

--- a/mappings/1.6-1517#1.6-1304.tinydiff
+++ b/mappings/1.6-1517#1.6-1304.tinydiff
@@ -9804,9 +9804,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/1.6.3-131100#1.6.3-171031.tinydiff
+++ b/mappings/1.6.3-131100#1.6.3-171031.tinydiff
@@ -9842,9 +9842,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/1.6.4-201309191549#1.6.4-201404010657.tinydiff
+++ b/mappings/1.6.4-201309191549#1.6.4-201404010657.tinydiff
@@ -9842,9 +9842,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/1.7-1602#1.7-1500.tinydiff
+++ b/mappings/1.7-1602#1.7-1500.tinydiff
@@ -10124,9 +10124,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/1.7.5-02260922#1.7.5-04010700.tinydiff
+++ b/mappings/1.7.5-02260922#1.7.5-04010700.tinydiff
@@ -10341,9 +10341,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w03a-1647#13w03a-1538.tinydiff
+++ b/mappings/13w03a-1647#13w03a-1538.tinydiff
@@ -10132,9 +10132,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w16a-191517#13w16a-181800.tinydiff
+++ b/mappings/13w16a-191517#13w16a-181800.tinydiff
@@ -9824,9 +9824,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w16b-2151#13w16b-2118.tinydiff
+++ b/mappings/13w16b-2151#13w16b-2118.tinydiff
@@ -9810,9 +9810,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w22a-1434#13w22a-1608.tinydiff
+++ b/mappings/13w22a-1434#13w22a-1608.tinydiff
@@ -9767,9 +9767,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w23b-0101#13w23b-0033.tinydiff
+++ b/mappings/13w23b-0101#13w23b-0033.tinydiff
@@ -9737,9 +9737,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w36a-1234#13w36a-1330.tinydiff
+++ b/mappings/13w36a-1234#13w36a-1330.tinydiff
@@ -9964,9 +9964,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w36b#13w36b-1233.tinydiff
+++ b/mappings/13w36b#13w36b-1233.tinydiff
@@ -9998,9 +9998,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w38c-1516#13w38c-1511.tinydiff
+++ b/mappings/13w38c-1516#13w38c-1511.tinydiff
@@ -10060,9 +10060,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w39a-1511#13w39a-1627.tinydiff
+++ b/mappings/13w39a-1511#13w39a-1627.tinydiff
@@ -10092,9 +10092,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/13w41b#13w41b-1507.tinydiff
+++ b/mappings/13w41b#13w41b-1507.tinydiff
@@ -10211,9 +10211,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/14w04a-1526#14w04a-1740.tinydiff
+++ b/mappings/14w04a-1526#14w04a-1740.tinydiff
@@ -9803,9 +9803,9 @@ c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera
 	f	F	f_14820533	x	
 	f	F	f_79596197	y	
 	f	F	f_50356219	z	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/14w04a-1740#14w04a.tinydiff
+++ b/mappings/14w04a-1740#14w04a.tinydiff
@@ -17913,9 +17913,9 @@ c	net/minecraft/unmapped/C_93577926		net/minecraft/client/render/Camera
 	f	F	f_14820533		x
 	f	F	f_79596197		y
 	f	F	f_50356219		z
-	f	Ljava/nio/IntBuffer;	f_19076117		glIntBuffer
-	f	Ljava/nio/FloatBuffer;	f_67310505		glFloatBuffer1
-	f	Ljava/nio/FloatBuffer;	f_04121695		glFloatBuffer2
+	f	Ljava/nio/IntBuffer;	f_19076117		VIEWPORT_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_67310505		MODELVIEW_MATRIX_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_04121695		PROJECTION_MATRIX_BUFFER
 	f	Ljava/nio/FloatBuffer;	f_17323686		POSITION_BUFFER
 	f	F	f_01695376		dx
 	f	F	f_00169964		dy

--- a/mappings/14w10c-1351#14w10c-1518.tinydiff
+++ b/mappings/14w10c-1351#14w10c-1518.tinydiff
@@ -9814,9 +9814,9 @@ c	net/minecraft/unmapped/C_91973056	net/minecraft/client/render/model/block/enti
 		p	1		reduction	
 		p	2		base	
 c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/14w11b#14w11b-1640.tinydiff
+++ b/mappings/14w11b#14w11b-1640.tinydiff
@@ -9847,9 +9847,9 @@ c	net/minecraft/unmapped/C_91973056	net/minecraft/client/render/model/block/enti
 		p	1		reduction	
 		p	2		base	
 c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/17w18a-1450#17w18a-1331.tinydiff
+++ b/mappings/17w18a-1450#17w18a-1331.tinydiff
@@ -10358,9 +10358,9 @@ c	net/minecraft/unmapped/C_91973056	net/minecraft/client/render/model/block/enti
 		p	1		reduction	
 		p	2		base	
 c	net/minecraft/unmapped/C_93577926	net/minecraft/client/render/Camera	
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	F	f_01695376	dx	
 	f	F	f_00169964	dy	

--- a/mappings/17w43b#17w45a.tinydiff
+++ b/mappings/17w43b#17w45a.tinydiff
@@ -1958,9 +1958,9 @@ c	net/minecraft/unmapped/C_83946278
 	m	(Lnet/minecraft/unmapped/C_30281404;)Z	m_63240372		m_63240372
 		p	1			p_1
 c	net/minecraft/unmapped/C_93577926
-	f	Ljava/nio/IntBuffer;	f_19076117	glIntBuffer	
-	f	Ljava/nio/FloatBuffer;	f_67310505	glFloatBuffer1	
-	f	Ljava/nio/FloatBuffer;	f_04121695	glFloatBuffer2	
+	f	Ljava/nio/IntBuffer;	f_19076117	VIEWPORT_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_67310505	MODELVIEW_MATRIX_BUFFER	
+	f	Ljava/nio/FloatBuffer;	f_04121695	PROJECTION_MATRIX_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_17323686	POSITION_BUFFER	
 	f	Ljava/nio/FloatBuffer;	f_03468916		f_03468916
 	m	(Lnet/minecraft/unmapped/C_40996800;Z)V	m_15661785	setup	

--- a/mappings/b1.9-pre6#1.0.0-rc2-1656.tinydiff
+++ b/mappings/b1.9-pre6#1.0.0-rc2-1656.tinydiff
@@ -51,9 +51,9 @@ c	net/minecraft/unmapped/C_93577926		net/minecraft/client/render/Camera
 	f	F	f_14820533		x
 	f	F	f_79596197		y
 	f	F	f_50356219		z
-	f	Ljava/nio/IntBuffer;	f_19076117		glIntBuffer
-	f	Ljava/nio/FloatBuffer;	f_67310505		glFloatBuffer1
-	f	Ljava/nio/FloatBuffer;	f_04121695		glFloatBuffer2
+	f	Ljava/nio/IntBuffer;	f_19076117		VIEWPORT_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_67310505		MODELVIEW_MATRIX_BUFFER
+	f	Ljava/nio/FloatBuffer;	f_04121695		PROJECTION_MATRIX_BUFFER
 	f	Ljava/nio/FloatBuffer;	f_17323686		POSITION_BUFFER
 	f	F	f_01695376		dx
 	f	F	f_00169964		dy


### PR DESCRIPTION
<14w05a have these fields non-final too, but tool seemed to hate my attempts to propagate camel case only to these versions