### PR TITLE
fix creative flight speed bug from duplicate mapping name

### DIFF
--- a/mappings/b1.7.3#b1.8-pre1-091358.tinydiff
+++ b/mappings/b1.7.3#b1.8-pre1-091358.tinydiff
@@ -755,7 +755,7 @@ c	net/minecraft/unmapped/C_40996800
 	f	I	f_28438659		itemUseTimer
 		c		The amount of ticks the current item being used has been in use for.
 	f	F	f_57752812		speed
-	f	F	f_76552083		flyingSpeed
+	f	F	f_76552083		airSpeed
 	m	(Lnet/minecraft/unmapped/C_42232651;)V	m_21437816	m_21437816	
 		p	1		p_1	
 	m	(Lnet/minecraft/unmapped/C_42232651;I)Z	m_40469716	m_40469716	


### PR DESCRIPTION
Due to two fields sharing the name "flyingSpeed" in the mappings, one in net.minecraft.entity.mob.MobEntity and the other in net.minecraft.entity.mob.player.PlayerEntity, Creative mode flight would be stuck with a flight speed of 0.02f in development environments. The default is 0.05f, although this can be customized.

I renamed the field in net.minecraft.entity.mob.player.PlayerEntity. It's used to calculate how fast a player moves while falling mid-air, so I renamed to to "airSpeed".