### PR TITLE
Change LivingEntity#get/setHandInUse to get/setActiveHand for more consistency

### DIFF
--- a/mappings/1.8.8#15w31a.tinydiff
+++ b/mappings/1.8.8#15w31a.tinydiff
@@ -1227,9 +1227,9 @@ c	net/minecraft/unmapped/C_74425583
 		p	2			p_2
 	m	()Lnet/minecraft/unmapped/C_88672107;	m_82780045		getMainArm
 	m	()Z	m_73195969		isUsingItem
-	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getHandInUse
+	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getActiveHand
 	m	()V	m_74084220		tickUsingItem
-	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setHandInUse
+	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setActiveHand
 		p	1			hand
 	m	(I)V	m_36524865		m_36524865
 		p	1			p_1

--- a/mappings/1.8.9#15w45a.tinydiff
+++ b/mappings/1.8.9#15w45a.tinydiff
@@ -4091,9 +4091,9 @@ c	net/minecraft/unmapped/C_74425583
 	m	()V	m_91988068		m_91988068
 	m	()Lnet/minecraft/unmapped/C_88672107;	m_82780045		getMainArm
 	m	()Z	m_73195969		isUsingItem
-	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getHandInUse
+	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getActiveHand
 	m	()V	m_74084220		tickUsingItem
-	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setHandInUse
+	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setActiveHand
 		p	1			hand
 	m	(Lnet/minecraft/unmapped/C_63353360;)V	m_36524865		m_36524865
 		p	1			p_1

--- a/mappings/1.8.9#16w04a.tinydiff
+++ b/mappings/1.8.9#16w04a.tinydiff
@@ -4534,9 +4534,9 @@ c	net/minecraft/unmapped/C_74425583
 	m	()V	m_91988068		m_91988068
 	m	()Lnet/minecraft/unmapped/C_88672107;	m_82780045		getMainArm
 	m	()Z	m_73195969		isUsingItem
-	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getHandInUse
+	m	()Lnet/minecraft/unmapped/C_31276856;	m_60648870		getActiveHand
 	m	()V	m_74084220		tickUsingItem
-	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setHandInUse
+	m	(Lnet/minecraft/unmapped/C_31276856;)V	m_00971184		setActiveHand
 		p	1			hand
 	m	(Lnet/minecraft/unmapped/C_63353360;)V	m_36524865		m_36524865
 		p	1			p_1


### PR DESCRIPTION
Hi, this is my first mappings pull request, so I hope I did everything right.

Using 1.12, in `LocalClientPlayerEntity` I noticed that the getters and setters for `activeHand` were called `get/setHandInUse` (overwritten from `LivingEntity`). I changed it to `get/setActiveHand` for more consistency